### PR TITLE
Convert code to Python 3 and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Each module in the software package was designed to be highly specific. This mea
 
 ## Installation
 
-Clone the repo from github:  
+Clone the repo from github:
 `git clone https://github.com/snayfach/MAGpurify`
 
 Install required python libraries:
 `pip install --user pandas numpy sklearn biopython`
 
-Install 3rd party programs:  	
+Install 3rd party programs:
 
 * [BLAST (v2.7.1)](https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=Download)
 * [Prodigal (v2.6.3)](https://github.com/hyattpd/Prodigal)
@@ -26,12 +26,12 @@ Install 3rd party programs:
 
 Download the reference database: [MAGpurify-db-v1.0.tar.bz2](http://bit.ly/MAGpurify-db)
 
-And unpack the database:  
-`tar -jxvf MAGpurify-db-v1.0.tar.bz2`   
+And unpack the database:
+`tar -jxvf MAGpurify-db-v1.0.tar.bz2`
 
- Update your environment:  
-`export PATH=$PATH:/path/to/MAGpurify`   
-`export MAGPURIFYDB=/path/to/MAGpurify-db-v1.0`   
+ Update your environment:
+`export PATH=$PATH:/path/to/MAGpurify`
+`export MAGPURIFYDB=/path/to/MAGpurify-db-v1.0`
 
 
 ## A quick overview
@@ -55,8 +55,8 @@ Commands:
 Note: use run_qc.py <command> -h to view usage for a specific command
 ```
 
-First, identify incorrectly binned contigs using: `run_qc.py <command> <input genome> <output directory>`  
-And then remove these contigs using: `run_qc.py clean-bin <input genome> <output directory>`  
+First, identify incorrectly binned contigs using: `run_qc.py <command> <input genome> <output directory>`
+And then remove these contigs using: `run_qc.py clean-bin <input genome> <output directory>`
 It's as simple as that!
 
 All of the modules can be run using the standard MAGpurify database, with the exception of the `conspecific` module which requires that you build your own database (see below)
@@ -65,18 +65,18 @@ All of the modules can be run using the standard MAGpurify database, with the ex
 
 The next few lines will show you how to run the software using a single MAG included with the software.
 
-First, run the individual modules to predict contamination in the example `example/test.fna` file and store the results in `example/output`:  
-`run_qc.py phylo-markers example/test.fna example/output`  
-`run_qc.py clade-markers example/test.fna example/output`  
-`run_qc.py tetra-freq example/test.fna example/output`  
-`run_qc.py gc-content example/test.fna example/output`  
-`run_qc.py known-contam example/test.fna example/output`  
+First, run the individual modules to predict contamination in the example `example/test.fna` file and store the results in `example/output`:
+`run_qc.py phylo-markers example/test.fna example/output`
+`run_qc.py clade-markers example/test.fna example/output`
+`run_qc.py tetra-freq example/test.fna example/output`
+`run_qc.py gc-content example/test.fna example/output`
+`run_qc.py known-contam example/test.fna example/output`
 
-The output of each module is stored in the output directory:  
-`ls example/output`  
+The output of each module is stored in the output directory:
+`ls example/output`
 `> clade-markers gc-content  known-contam  phylo-markers  tetra-freq`
 
-Now remove the contamintion from the bin:  
+Now remove the contamintion from the bin:
 `run_qc.py clean-bin example/test.fna example/output`
 
 You should see the following output:
@@ -103,13 +103,13 @@ In summary, 3 of the 6 modules predicted at least one contaminant and the cleane
 
 ## An example using the conspecific module
 
-To run the conspecific module, you need to build your own reference database using Mash. We have provided some dummy files to illustrate this:  
+To run the conspecific module, you need to build your own reference database using Mash. We have provided some dummy files to illustrate this:
 `mash sketch -l example/ref_genomes.list -o example/ref_genomes`
 
 Which will create a Mash sketch of the genomes listed in `example/ref_genomes.list` that are located in `example/ref_genomes`. The sketch will be written to `example/ref_genomes.msh`
 
-Now you can run the conspecific module: 
-`run_qc.py conspecific example/test.fna example/output --mash-sketch example/ref_genomes.msh`  
+Now you can run the conspecific module:
+`run_qc.py conspecific example/test.fna example/output --mash-sketch example/ref_genomes.msh`
 
 Which should produce the output:
 
@@ -135,23 +135,23 @@ So, the conspecific module alone identified 238 putative contaminants! This illu
 
 ## Details on the individual modules
 
-<b>phylo-markers</b>  
+<b>phylo-markers</b>
 This module works by taxonomically annotating your contigs based on a database of phylogenetic marker genes from the PhyEco database and identifying taxonomically discordant contigs.
 
-<b>clade-markers</b>   
-This module works in a very similar way to `phylo-markers`, but instead uses clade-specific markers from the MetaPhlAn 2 database for taxonomic annotation. 
+<b>clade-markers</b>
+This module works in a very similar way to `phylo-markers`, but instead uses clade-specific markers from the MetaPhlAn 2 database for taxonomic annotation.
 
-<b>conspecific</b>   
-The logic behind this module is that strains of the same species should have similarity along most of the genome. Therefore, this module works by first finding strains of the same species, and then performing pairwise alignment of contigs. Contaminants are identified which do not align at all between genomes. 
+<b>conspecific</b>
+The logic behind this module is that strains of the same species should have similarity along most of the genome. Therefore, this module works by first finding strains of the same species, and then performing pairwise alignment of contigs. Contaminants are identified which do not align at all between genomes.
 
-<b>tetra-freq</b>   
+<b>tetra-freq</b>
 This module works by identifying contigs with outlier nucleotide composition based on tetranucleotide frequencies (TNF). In order to reduce TNF down to a single dimension, principal component analysis (PCA) is performed and the first principal component is used.
 
-<b>gc-content</b>   
+<b>gc-content</b>
 This module works by identifying contigs with outlier nucleotide composition based on GC content.
 
-<b>known-contam</b>   
+<b>known-contam</b>
 This module works by identifying contigs that match a database of known contaminants. So far, the human genome and phiX genome are the only ones in the database.
 
-<b>read-depth</b>   
+<b>read-depth</b>
 <i>coming soon...</i>

--- a/magpurify/clean.py
+++ b/magpurify/clean.py
@@ -1,134 +1,145 @@
 #!/usr/bin/env python
 
 import os
-import utility
+from . import utility
 import sys
 import argparse
 from operator import itemgetter
 
+
 def fetch_args():
-	parser = argparse.ArgumentParser(
-		formatter_class=argparse.RawTextHelpFormatter,
-		usage=argparse.SUPPRESS,
-		description="MAGpurify: clean module: remove flagged contigs from input genome"
-	)
-	parser.add_argument('program', help=argparse.SUPPRESS)
-	parser.add_argument('fna', type=str,
-		help="""Path to input genome in FASTA format""")
-	parser.add_argument('out', type=str,
-		help="""Output directory to store results and intermediate files""")
-	args = vars(parser.parse_args())
-	return args
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description="MAGpurify: clean module: remove flagged contigs from input genome",
+    )
+    parser.add_argument('program', help=argparse.SUPPRESS)
+    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument(
+        'out',
+        type=str,
+        help="""Output directory to store results and intermediate files""",
+    )
+    args = vars(parser.parse_args())
+    return args
+
 
 def main():
 
-	args = fetch_args()
-	
-	utility.check_input(args)
-	
-	print("\n## Reading genome bin")
-	bin = {}
-	for id, seq in utility.parse_fasta(args['fna']):
-		bin[id] = seq
-	bin_length = round(sum([len(_) for _ in bin.values()])/1000.0,2)
-	print("   genome length: %s contigs, %s Kbp" % (len(bin), bin_length))
+    args = fetch_args()
 
-	print("\n## Reading flagged contigs")
-	flagged_contigs = []
-	programs = ['phylo-markers', 'clade-markers', 'conspecific', 'tetra-freq', 'gc-content', 'known-contam']
-	for program in programs:
-		path = '%s/%s/flagged_contigs' % (args['out'], program)
-		if not os.path.exists(path):
-			print("   %s: no output file found" % program)
-		else:
-			contigs = [_.rstrip() for _ in open(path)]
-			bases = round(sum([len(bin[id]) for id in contigs])/1000.0,2)
-			flagged_contigs += contigs
-			print("   %s: %s contigs, %s Kbp" % (program, len(contigs), bases))
-	flagged_contigs = list(set(flagged_contigs))
-	flagged_length = round(sum([len(bin[id]) for id in flagged_contigs])/1000.0,2)
+    utility.check_input(args)
 
-	print("\n## Removing flagged contigs")
-	clean = bin.copy()
-	for id in flagged_contigs:
-		del clean[id]
-	clean_length = round(sum([len(_) for _ in clean.values()])/1000.0,2)
-	print("   removed: %s contigs, %s Kbp" % (len(flagged_contigs), flagged_length))
-	print("   remains: %s contigs, %s Kbp" % (len(clean), clean_length))
+    print("\n## Reading genome bin")
+    bin = {}
+    for id, seq in utility.parse_fasta(args['fna']):
+        bin[id] = seq
+    bin_length = round(sum(len(_) for _ in bin.values()) / 1000, 2)
+    print("   genome length: %s contigs, %s Kbp" % (len(bin), bin_length))
 
-	out = '%s/cleaned_bin.fna' % args['out']
-	with open(out, 'w') as f:
-		for id, seq in clean.items():
-			f.write('>'+id+'\n'+seq+'\n')
-	print("   cleaned bin: %s" % out)
+    print("\n## Reading flagged contigs")
+    flagged_contigs = []
+    programs = [
+        'phylo-markers',
+        'clade-markers',
+        'conspecific',
+        'tetra-freq',
+        'gc-content',
+        'known-contam',
+    ]
+    for program in programs:
+        path = '%s/%s/flagged_contigs' % (args['out'], program)
+        if not os.path.exists(path):
+            print("   %s: no output file found" % program)
+        else:
+            contigs = [_.rstrip() for _ in open(path)]
+            bases = round(sum(len(bin[id]) for id in contigs) / 1000, 2)
+            flagged_contigs += contigs
+            print("   %s: %s contigs, %s Kbp" % (program, len(contigs), bases))
+    flagged_contigs = list(set(flagged_contigs))
+    flagged_length = round(sum(len(bin[id]) for id in flagged_contigs) / 1000, 2)
+
+    print("\n## Removing flagged contigs")
+    clean = bin.copy()
+    for id in flagged_contigs:
+        del clean[id]
+    clean_length = round(sum(len(_) for _ in clean.values()) / 1000, 2)
+    print("   removed: %s contigs, %s Kbp" % (len(flagged_contigs), flagged_length))
+    print("   remains: %s contigs, %s Kbp" % (len(clean), clean_length))
+
+    out = '%s/cleaned_bin.fna' % args['out']
+    with open(out, 'w') as f:
+        for id, seq in clean.items():
+            f.write('>' + id + '\n' + seq + '\n')
+    print("   cleaned bin: %s" % out)
 
 
-#	check_input(args)
-#	check_database(args)
+#    check_input(args)
+#    check_database(args)
 #
-#	contigs = {}
-#	for rec in parse_fasta(args['fna_path']):
-#		contig = Contig()
-#		contig.id = rec.id
-#		contig.seq = str(rec.seq)
-#		contig.length = len(rec.seq)
-#		contig.flags = []
-#		contigs[rec.id] = contig
+#    contigs = {}
+#    for rec in parse_fasta(args['fna_path']):
+#        contig = Contig()
+#        contig.id = rec.id
+#        contig.seq = str(rec.seq)
+#        contig.length = len(rec.seq)
+#        contig.flags = []
+#        contigs[rec.id] = contig
 #
-#	if args['modules'] and 'uscmg' in args['modules']:
-#		from magpurify import uscmg
-#		check_dependencies(['prodigal', 'blastp', 'hmmsearch'])
-#		sys.stdout.write("discordant taxonomy based on universal-single-copy marker-genes\n")
-#		flagged = magpurify.uscmg.main(args)
-#		for id in flagged:
-#			contigs[id].flags.append('uscmg')
-#		sys.stdout.write("   %s contigs flagged\n" % len(flagged))
+#    if args['modules'] and 'uscmg' in args['modules']:
+#        from magpurify import uscmg
+#        check_dependencies(['prodigal', 'blastp', 'hmmsearch'])
+#        sys.stdout.write("discordant taxonomy based on universal-single-copy marker-genes\n")
+#        flagged = magpurify.uscmg.main(args)
+#        for id in flagged:
+#            contigs[id].flags.append('uscmg')
+#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
 #
-#	if args['modules'] and 'csmg' in args['modules']:
-#		from magpurify import csmg
-#		check_dependencies(['prodigal', 'lastal'])
-#		sys.stdout.write("discordant taxonomy based on clade-specific marker-genes\n")
-#		flagged = csmg.main(args)
-#		for id in flagged:
-#			contigs[id].flags.append('csmg')
-#		sys.stdout.write("   %s contigs flagged\n" % len(flagged))
+#    if args['modules'] and 'csmg' in args['modules']:
+#        from magpurify import csmg
+#        check_dependencies(['prodigal', 'lastal'])
+#        sys.stdout.write("discordant taxonomy based on clade-specific marker-genes\n")
+#        flagged = csmg.main(args)
+#        for id in flagged:
+#            contigs[id].flags.append('csmg')
+#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
 #
-#	if args['modules'] and 'contdb' in args['modules']:
-#		from magpurify import contam
-#		check_dependencies(['blastn'])
-#		sys.stdout.write("hits to database of contaminants\n")
-#		flagged = contam.main(args)
-#		for id in flagged:
-#			contigs[id].flags.append('contdb')
-#		sys.stdout.write("   %s contigs flagged\n" % len(flagged))
+#    if args['modules'] and 'contdb' in args['modules']:
+#        from magpurify import contam
+#        check_dependencies(['blastn'])
+#        sys.stdout.write("hits to database of contaminants\n")
+#        flagged = contam.main(args)
+#        for id in flagged:
+#            contigs[id].flags.append('contdb')
+#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
 #
-#	if args['modules'] and 'tnf' in args['modules']:
-#		check_dependencies([])
-#		sys.stdout.write("outlier tetranucleotide frequency\n")
-#		from magpurify import tetra
-#		flagged = tetra.main(args)
-#		for id in flagged:
-#			contigs[id].flags.append('tnf')
-#		sys.stdout.write("   %s contigs flagged\n" % len(flagged))
+#    if args['modules'] and 'tnf' in args['modules']:
+#        check_dependencies([])
+#        sys.stdout.write("outlier tetranucleotide frequency\n")
+#        from magpurify import tetra
+#        flagged = tetra.main(args)
+#        for id in flagged:
+#            contigs[id].flags.append('tnf')
+#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
 #
-#	if args['modules'] and 'gc' in args['modules']:
-#		check_dependencies([])
-#		sys.stdout.write("outlier gc content\n")
-#		from magpurify import gc
-#		flagged = gc.main(args)
-#		for id in flagged:
-#			contigs[id].flags.append('gcc')
-#		sys.stdout.write("   %s contigs flagged\n" % len(flagged))
+#    if args['modules'] and 'gc' in args['modules']:
+#        check_dependencies([])
+#        sys.stdout.write("outlier gc content\n")
+#        from magpurify import gc
+#        flagged = gc.main(args)
+#        for id in flagged:
+#            contigs[id].flags.append('gcc')
+#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
 #
-#	with open('%s/cleaned.fa' % args['out_dir'], 'w') as f:
-#		for contig in contigs.values():
-#			if len(contig.flags) > 0:
-#				continue
-#			f.write('>'+contig.id+'\n'+contig.seq+'\n')
+#    with open('%s/cleaned.fa' % args['out_dir'], 'w') as f:
+#        for contig in contigs.values():
+#            if len(contig.flags) > 0:
+#                continue
+#            f.write('>'+contig.id+'\n'+contig.seq+'\n')
 #
-#	with open('%s/summary.tsv' % args['out_dir'], 'w') as f:
-#		fields = ['contig_id', 'length', 'flags']
-#		f.write('\t'.join(fields)+'\n')
-#		for contig in contigs.values():
-#			values = [contig.id, str(contig.length), ','.join(contig.flags)]
-#			f.write('\t'.join(values)+'\n')
+#    with open('%s/summary.tsv' % args['out_dir'], 'w') as f:
+#        fields = ['contig_id', 'length', 'flags']
+#        f.write('\t'.join(fields)+'\n')
+#        for contig in contigs.values():
+#            values = [contig.id, str(contig.length), ','.join(contig.flags)]
+#            f.write('\t'.join(values)+'\n')

--- a/magpurify/clean.py
+++ b/magpurify/clean.py
@@ -25,11 +25,8 @@ def fetch_args():
 
 
 def main():
-
     args = fetch_args()
-
     utility.check_input(args)
-
     print("\n## Reading genome bin")
     bin = {}
     for id, seq in utility.parse_fasta(args['fna']):
@@ -58,7 +55,6 @@ def main():
             print("   %s: %s contigs, %s Kbp" % (program, len(contigs), bases))
     flagged_contigs = list(set(flagged_contigs))
     flagged_length = round(sum(len(bin[id]) for id in flagged_contigs) / 1000, 2)
-
     print("\n## Removing flagged contigs")
     clean = bin.copy()
     for id in flagged_contigs:
@@ -66,7 +62,6 @@ def main():
     clean_length = round(sum(len(_) for _ in clean.values()) / 1000, 2)
     print("   removed: %s contigs, %s Kbp" % (len(flagged_contigs), flagged_length))
     print("   remains: %s contigs, %s Kbp" % (len(clean), clean_length))
-
     out = '%s/cleaned_bin.fna' % args['out']
     with open(out, 'w') as f:
         for id, seq in clean.items():

--- a/magpurify/conspecific.py
+++ b/magpurify/conspecific.py
@@ -128,6 +128,7 @@ def blastn(query, target, outdir, id):
         cmd += "-max_target_seqs 1 -max_hsps 1 "
         cmd += "-query %s -subject %s " % (query, target)
         out, err = utility.run_process(cmd)
+        out = out.decode("utf-8")
         open(out_path, 'w').write(out)
     else:
         out = open(out_path).read()

--- a/magpurify/conspecific.py
+++ b/magpurify/conspecific.py
@@ -1,191 +1,254 @@
 #!/usr/bin/env python
 
 import os
-import utility
+from . import utility
 import sys
 import argparse
 from operator import itemgetter
 
+
 def fetch_args():
-	parser = argparse.ArgumentParser(
-		formatter_class=argparse.RawTextHelpFormatter,
-		usage=argparse.SUPPRESS,
-		description="MAGpurify: conspecific module: identify contigs that fail to align to closely related genomes"
-	)
-	parser.add_argument('program', help=argparse.SUPPRESS)
-	parser.add_argument('fna', type=str,
-		help="""Path to input genome in FASTA format""")
-	parser.add_argument('out', type=str,
-		help="""Output directory to store results and intermediate files""")
-	parser.add_argument('--threads', type=int, default=1, metavar='INT',
-		help="""Number of CPUs to use (default=1)""")
-	parser.add_argument('--mash-sketch', type=str, metavar='PATH', required=True,
-		help="""Path to Mash sketch of reference genomes""")
-	parser.add_argument('--mash-dist', type=float, default=0.05, metavar='FLOAT',
-		help="Mash distance to reference genomes (default=0.05)")
-	parser.add_argument('--max-genomes', type=int, default=25, metavar='INT',
-		help="Max number of genomes to use (default=25)")
-	parser.add_argument('--min-genomes', type=int, default=1, metavar='INT',
-		help="Min number of genomes to use (default=1)")
-	parser.add_argument('--contig-aln', type=float, default=0.50, metavar='FLOAT',
-		help="Minimum fraction of contig aligned to reference (default=0.50)")
-	parser.add_argument('--contig-pid', type=float, default=95.0, metavar='FLOAT',
-		help="Minimum percent identity of contig aligned to reference (default=95.0)")
-	parser.add_argument('--hit-rate', type=float, default=0.00, metavar='FLOAT',
-		help="Hit rate for flagging contigs (default=0.00)")
-	parser.add_argument('--exclude', default='', metavar='STR',
-		help="Comma-separated list of references to exclude")
-	args = vars(parser.parse_args())
-	args['exclude'] = args['exclude'].split(',')
-	return args
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description="MAGpurify: conspecific module: identify contigs that fail to align to closely related genomes",
+    )
+    parser.add_argument('program', help=argparse.SUPPRESS)
+    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument(
+        'out',
+        type=str,
+        help="""Output directory to store results and intermediate files""",
+    )
+    parser.add_argument(
+        '--threads',
+        type=int,
+        default=1,
+        metavar='INT',
+        help="""Number of CPUs to use (default=1)""",
+    )
+    parser.add_argument(
+        '--mash-sketch',
+        type=str,
+        metavar='PATH',
+        required=True,
+        help="""Path to Mash sketch of reference genomes""",
+    )
+    parser.add_argument(
+        '--mash-dist',
+        type=float,
+        default=0.05,
+        metavar='FLOAT',
+        help="Mash distance to reference genomes (default=0.05)",
+    )
+    parser.add_argument(
+        '--max-genomes',
+        type=int,
+        default=25,
+        metavar='INT',
+        help="Max number of genomes to use (default=25)",
+    )
+    parser.add_argument(
+        '--min-genomes',
+        type=int,
+        default=1,
+        metavar='INT',
+        help="Min number of genomes to use (default=1)",
+    )
+    parser.add_argument(
+        '--contig-aln',
+        type=float,
+        default=0.50,
+        metavar='FLOAT',
+        help="Minimum fraction of contig aligned to reference (default=0.50)",
+    )
+    parser.add_argument(
+        '--contig-pid',
+        type=float,
+        default=95.0,
+        metavar='FLOAT',
+        help="Minimum percent identity of contig aligned to reference (default=95.0)",
+    )
+    parser.add_argument(
+        '--hit-rate',
+        type=float,
+        default=0.00,
+        metavar='FLOAT',
+        help="Hit rate for flagging contigs (default=0.00)",
+    )
+    parser.add_argument(
+        '--exclude',
+        default='',
+        metavar='STR',
+        help="Comma-separated list of references to exclude",
+    )
+    args = vars(parser.parse_args())
+    args['exclude'] = args['exclude'].split(',')
+    return args
+
 
 def run_mash(mash_sketch, fna_path, tmp_dir, threads=1):
-	out_path = '%s/mash.dist' % tmp_dir
-	command = "mash dist -p %s -d 0.25 %s %s > %s" % (threads, fna_path, mash_sketch, out_path)
-	out, err = utility.run_process(command)
-	with open(tmp_dir+'/id_map.tsv', 'w') as f:
-		for id, rec in enumerate(utility.parse_mash(out_path)):
-			f.write(str(id)+'\t'+rec['target']+'\n')
+    out_path = '%s/mash.dist' % tmp_dir
+    command = "mash dist -p %s -d 0.25 %s %s > %s" % (
+        threads,
+        fna_path,
+        mash_sketch,
+        out_path,
+    )
+    out, err = utility.run_process(command)
+    with open(tmp_dir + '/id_map.tsv', 'w') as f:
+        for id, rec in enumerate(utility.parse_mash(out_path)):
+            f.write(str(id) + '\t' + rec['target'] + '\n')
+
 
 def find_conspecific(tmp_dir, max_dist, exclude):
 
-	targets = []
-	for rec in utility.parse_mash('%s/mash.dist' % tmp_dir):
-		if rec['query'] == rec['target']:
-			continue
-		elif rec['dist'] > max_dist:
-			continue
-		elif rec['pvalue'] > 1e-3:
-			continue
-		elif rec['target'] in exclude:
-			continue
-		else:
-			targets.append([rec['target'], rec['dist']])
+    targets = []
+    for rec in utility.parse_mash('%s/mash.dist' % tmp_dir):
+        if rec['query'] == rec['target']:
+            continue
+        elif rec['dist'] > max_dist:
+            continue
+        elif rec['pvalue'] > 1e-3:
+            continue
+        elif rec['target'] in exclude:
+            continue
+        else:
+            targets.append([rec['target'], rec['dist']])
 
-	targets = sorted(targets, key=itemgetter(1))
+    targets = sorted(targets, key=itemgetter(1))
 
-	return targets
+    return targets
+
 
 def blastn(query, target, outdir, id):
-	out_path = outdir+'/'+id+'.m8'
-	if not os.path.exists(out_path):
-		cmd = "blastn -outfmt '6 std qlen slen' "
-		cmd += "-max_target_seqs 1 -max_hsps 1 "
-		cmd += "-query %s -subject %s " % (query, target)
-		out, err = utility.run_process(cmd)
-		open(out_path, 'w').write(out)
-	else:
-		out = open(out_path).read()
-	return out
+    out_path = outdir + '/' + id + '.m8'
+    if not os.path.exists(out_path):
+        cmd = "blastn -outfmt '6 std qlen slen' "
+        cmd += "-max_target_seqs 1 -max_hsps 1 "
+        cmd += "-query %s -subject %s " % (query, target)
+        out, err = utility.run_process(cmd)
+        open(out_path, 'w').write(out)
+    else:
+        out = open(out_path).read()
+    return out
+
 
 def id_blast_hits(blast_out, min_aln, min_pid):
-	blast_hits = set([])
-	for rec in utility.parse_blast(blast_out, type='string'):
-		if rec['qcov'] < min_aln:
-			continue
-		elif rec['pid'] < min_pid:
-			continue
-		else:
-			blast_hits.add(rec['qname'])
-	return blast_hits
+    blast_hits = set([])
+    for rec in utility.parse_blast(blast_out, type='string'):
+        if rec['qcov'] < min_aln:
+            continue
+        elif rec['pid'] < min_pid:
+            continue
+        else:
+            blast_hits.add(rec['qname'])
+    return blast_hits
+
 
 def align_contigs(args, genomes):
-	target_to_id = {}
-	for line in open(args['tmp_dir']+'/id_map.tsv'):
-		id, target = line.split()
-		target_to_id[target] = id
-	alignments = []
-	for genome_path, mash_dist in genomes:
-		blast_out = blastn(args['fna'], genome_path, args['tmp_dir'], target_to_id[target])
-		alignments.append(blast_out)
-	return alignments
+    target_to_id = {}
+    for line in open(args['tmp_dir'] + '/id_map.tsv'):
+        id, target = line.split()
+        target_to_id[target] = id
+    alignments = []
+    for genome_path, mash_dist in genomes:
+        blast_out = blastn(
+            args['fna'], genome_path, args['tmp_dir'], target_to_id[target]
+        )
+        alignments.append(blast_out)
+    return alignments
+
 
 def find_contig_targets(args, genomes, alignments):
 
-	contigs = dict([(id,{'hits':0,'len':len(seq),'genomes':[]}) for id, seq in utility.parse_fasta(args['fna'])])
+    contigs = dict(
+        [
+            (id, {'hits': 0, 'len': len(seq), 'genomes': []})
+            for id, seq in utility.parse_fasta(args['fna'])
+        ]
+    )
 
-	for genome, alns in zip(genomes, alignments):
-		hits = id_blast_hits(alns, args['contig_aln'], args['contig_pid'])
-		for contig in hits:
-			contigs[contig]['hits'] += 1
-			contigs[contig]['genomes'].append(genome[0])
-	
-	for id in contigs:
-		hit_rate = contigs[id]['hits']/float(len(alignments))
-		contigs[id]['hit_rate'] = hit_rate
+    for genome, alns in zip(genomes, alignments):
+        hits = id_blast_hits(alns, args['contig_aln'], args['contig_pid'])
+        for contig in hits:
+            contigs[contig]['hits'] += 1
+            contigs[contig]['genomes'].append(genome[0])
 
-	return contigs
+    for id in contigs:
+        hit_rate = contigs[id]['hits'] / float(len(alignments))
+        contigs[id]['hit_rate'] = hit_rate
+
+    return contigs
+
 
 def flag_contigs(args, contigs):
-	flagged = []
-	for id in contigs:
-		if contigs[id]['hit_rate'] > args['hit_rate']:
-			continue
-		else:
-			flagged.append(id)
-	return flagged
+    flagged = []
+    for id in contigs:
+        if contigs[id]['hit_rate'] > args['hit_rate']:
+            continue
+        else:
+            flagged.append(id)
+    return flagged
+
 
 def main():
 
-	args = fetch_args()
-	
-	utility.add_tmp_dir(args)
-	utility.check_input(args)
-	utility.check_dependencies(['mash'])
-	if not os.path.exists(args['mash_sketch']):
-		sys.exit("\nError: mash sketch '%s' not found\n" % args['mash_sketch'])
+    args = fetch_args()
 
-	print ("\n## Finding conspecific genomes in database")
-	run_mash(args['mash_sketch'], args['fna'], args['tmp_dir'], args['threads'])
-	genomes = find_conspecific(args['tmp_dir'], args['mash_dist'], args['exclude'])
-	print ("   %s genomes within %s mash-dist" % (len(genomes), args['mash_dist']))
-	out = '%s/conspecific.list' % args['tmp_dir']
-	with open(out, 'w') as f:
-		f.write('genome_id\tmash_dist\n')
-		for genome_id, mash_dist in genomes:
-			f.write(genome_id+'\t'+str(mash_dist)+'\n')
-	print ("   list of genomes: %s" % (out))
-	print ("   mash output: %s/mash.dist" % args['tmp_dir'])
+    utility.add_tmp_dir(args)
+    utility.check_input(args)
+    utility.check_dependencies(['mash'])
+    if not os.path.exists(args['mash_sketch']):
+        sys.exit("\nError: mash sketch '%s' not found\n" % args['mash_sketch'])
 
-	if len(genomes) < args['min_genomes']:
-		sys.exit("\nError: insufficient number of conspecific genomes\n")
+    print("\n## Finding conspecific genomes in database")
+    run_mash(args['mash_sketch'], args['fna'], args['tmp_dir'], args['threads'])
+    genomes = find_conspecific(args['tmp_dir'], args['mash_dist'], args['exclude'])
+    print("   %s genomes within %s mash-dist" % (len(genomes), args['mash_dist']))
+    out = '%s/conspecific.list' % args['tmp_dir']
+    with open(out, 'w') as f:
+        f.write('genome_id\tmash_dist\n')
+        for genome_id, mash_dist in genomes:
+            f.write(genome_id + '\t' + str(mash_dist) + '\n')
+    print("   list of genomes: %s" % (out))
+    print("   mash output: %s/mash.dist" % args['tmp_dir'])
 
-	if len(genomes) > args['max_genomes']:
-		print ("\n## Selecting top %s most-similar genomes" % args['max_genomes'])
-		genomes = genomes[0:args['max_genomes']]
-		out = '%s/conspecific_subset.list' % args['tmp_dir']
-		with open(out, 'w') as f:
-			f.write('genome_id\tmash_dist\n')
-			for genome_id, mash_dist in genomes:
-				f.write(genome_id+'\t'+str(mash_dist)+'\n')
-		print ("   list of genomes: %s" % (out))
+    if len(genomes) < args['min_genomes']:
+        sys.exit("\nError: insufficient number of conspecific genomes\n")
 
-	print ("\n## Performing pairwise alignment of contigs in bin to database genomes")
-	alignments = align_contigs(args, genomes)
-	num_alns = sum([len(_.split('\n')) for _ in alignments])
-	print ("   total alignments: %s" % num_alns)
+    if len(genomes) > args['max_genomes']:
+        print("\n## Selecting top %s most-similar genomes" % args['max_genomes'])
+        genomes = genomes[0 : args['max_genomes']]
+        out = '%s/conspecific_subset.list' % args['tmp_dir']
+        with open(out, 'w') as f:
+            f.write('genome_id\tmash_dist\n')
+            for genome_id, mash_dist in genomes:
+                f.write(genome_id + '\t' + str(mash_dist) + '\n')
+        print("   list of genomes: %s" % (out))
 
-	print ("\n## Summarizing alignments")
-	contigs = find_contig_targets(args, genomes, alignments)
-	out = '%s/contig_hits.tsv' % args['tmp_dir']
-	with open(out, 'w') as f:
-		f.write('contig_id\tlength\talignment_rate\n')
-		for contig, values in contigs.items():
-			row = [contig, str(values['len']), '%s/%s' % (values['hits'], len(genomes))]
-			f.write('\t'.join(row)+'\n')
-	print ("   contig features: %s" % out)
+    print("\n## Performing pairwise alignment of contigs in bin to database genomes")
+    alignments = align_contigs(args, genomes)
+    num_alns = sum(len(_.split('\n')) for _ in alignments)
+    print("   total alignments: %s" % num_alns)
 
-	print ("\n## Identifying contigs with no conspecific alignments")
-	flagged_contigs = flag_contigs(args, contigs)
-	flagged_length = round(sum([contigs[id]['len'] for id in flagged_contigs])/1000.0,2)
-	print ("   %s flagged contigs, %s Kbp" % (len(flagged_contigs), flagged_length))
-	out = '%s/flagged_contigs' % args['tmp_dir']
-	with open(out, 'w') as f:
-		for contig in flagged_contigs:
-			f.write(contig+'\n')
-	print ("   flagged contigs: %s" % out)
+    print("\n## Summarizing alignments")
+    contigs = find_contig_targets(args, genomes, alignments)
+    out = '%s/contig_hits.tsv' % args['tmp_dir']
+    with open(out, 'w') as f:
+        f.write('contig_id\tlength\talignment_rate\n')
+        for contig, values in contigs.items():
+            row = [contig, str(values['len']), '%s/%s' % (values['hits'], len(genomes))]
+            f.write('\t'.join(row) + '\n')
+    print("   contig features: %s" % out)
 
-
-
-
+    print("\n## Identifying contigs with no conspecific alignments")
+    flagged_contigs = flag_contigs(args, contigs)
+    flagged_length = round(sum(contigs[id]['len'] for id in flagged_contigs) / 1000, 2)
+    print("   %s flagged contigs, %s Kbp" % (len(flagged_contigs), flagged_length))
+    out = '%s/flagged_contigs' % args['tmp_dir']
+    with open(out, 'w') as f:
+        for contig in flagged_contigs:
+            f.write(contig + '\n')
+    print("   flagged contigs: %s" % out)
 

--- a/magpurify/conspecific.py
+++ b/magpurify/conspecific.py
@@ -102,7 +102,6 @@ def run_mash(mash_sketch, fna_path, tmp_dir, threads=1):
 
 
 def find_conspecific(tmp_dir, max_dist, exclude):
-
     targets = []
     for rec in utility.parse_mash('%s/mash.dist' % tmp_dir):
         if rec['query'] == rec['target']:
@@ -115,9 +114,7 @@ def find_conspecific(tmp_dir, max_dist, exclude):
             continue
         else:
             targets.append([rec['target'], rec['dist']])
-
     targets = sorted(targets, key=itemgetter(1))
-
     return targets
 
 
@@ -162,24 +159,20 @@ def align_contigs(args, genomes):
 
 
 def find_contig_targets(args, genomes, alignments):
-
     contigs = dict(
         [
             (id, {'hits': 0, 'len': len(seq), 'genomes': []})
             for id, seq in utility.parse_fasta(args['fna'])
         ]
     )
-
     for genome, alns in zip(genomes, alignments):
         hits = id_blast_hits(alns, args['contig_aln'], args['contig_pid'])
         for contig in hits:
             contigs[contig]['hits'] += 1
             contigs[contig]['genomes'].append(genome[0])
-
     for id in contigs:
         hit_rate = contigs[id]['hits'] / float(len(alignments))
         contigs[id]['hit_rate'] = hit_rate
-
     return contigs
 
 
@@ -194,15 +187,12 @@ def flag_contigs(args, contigs):
 
 
 def main():
-
     args = fetch_args()
-
     utility.add_tmp_dir(args)
     utility.check_input(args)
     utility.check_dependencies(['mash'])
     if not os.path.exists(args['mash_sketch']):
         sys.exit("\nError: mash sketch '%s' not found\n" % args['mash_sketch'])
-
     print("\n## Finding conspecific genomes in database")
     run_mash(args['mash_sketch'], args['fna'], args['tmp_dir'], args['threads'])
     genomes = find_conspecific(args['tmp_dir'], args['mash_dist'], args['exclude'])
@@ -214,10 +204,8 @@ def main():
             f.write(genome_id + '\t' + str(mash_dist) + '\n')
     print("   list of genomes: %s" % (out))
     print("   mash output: %s/mash.dist" % args['tmp_dir'])
-
     if len(genomes) < args['min_genomes']:
         sys.exit("\nError: insufficient number of conspecific genomes\n")
-
     if len(genomes) > args['max_genomes']:
         print("\n## Selecting top %s most-similar genomes" % args['max_genomes'])
         genomes = genomes[0 : args['max_genomes']]
@@ -227,12 +215,10 @@ def main():
             for genome_id, mash_dist in genomes:
                 f.write(genome_id + '\t' + str(mash_dist) + '\n')
         print("   list of genomes: %s" % (out))
-
     print("\n## Performing pairwise alignment of contigs in bin to database genomes")
     alignments = align_contigs(args, genomes)
     num_alns = sum(len(_.split('\n')) for _ in alignments)
     print("   total alignments: %s" % num_alns)
-
     print("\n## Summarizing alignments")
     contigs = find_contig_targets(args, genomes, alignments)
     out = '%s/contig_hits.tsv' % args['tmp_dir']
@@ -242,7 +228,6 @@ def main():
             row = [contig, str(values['len']), '%s/%s' % (values['hits'], len(genomes))]
             f.write('\t'.join(row) + '\n')
     print("   contig features: %s" % out)
-
     print("\n## Identifying contigs with no conspecific alignments")
     flagged_contigs = flag_contigs(args, contigs)
     flagged_length = round(sum(contigs[id]['len'] for id in flagged_contigs) / 1000, 2)

--- a/magpurify/contam.py
+++ b/magpurify/contam.py
@@ -68,18 +68,14 @@ def run_blastn(query, db, out, threads, qcov=25, pid=98, evalue=1e-5):
 
 
 def main():
-
     args = fetch_args()
-
     utility.add_tmp_dir(args)
     utility.check_input(args)
     utility.check_dependencies(['blastn'])
     utility.check_database(args)
-
     tmp_dir = '%s/%s' % (args['out'], args['program'])
     if not os.path.exists(args['tmp_dir']):
         os.makedirs(args['tmp_dir'])
-
     print("\n## Searching database with BLASTN")
     for target in ['hg38', 'phix']:
         db = '%s/known-contam/%s/%s' % (args['db'], target, target)
@@ -93,7 +89,6 @@ def main():
             args['pid'],
             args['evalue'],
         )
-
     print("\n## Identifying contigs with hits to db")
     flagged = set([])
     for target in ['hg38', 'phix']:

--- a/magpurify/contam.py
+++ b/magpurify/contam.py
@@ -2,80 +2,108 @@
 
 import os
 import sys
-import utility
+from . import utility
 import argparse
 
+
 def fetch_args():
-	parser = argparse.ArgumentParser(
-		formatter_class=argparse.RawTextHelpFormatter,
-		usage=argparse.SUPPRESS,
-		description="MAGpurify: known-contam module: find contigs that match a database of known contaminants"
-	)
-	parser.add_argument('program', help=argparse.SUPPRESS)
-	parser.add_argument('fna', type=str,
-		help="""Path to input genome in FASTA format""")
-	parser.add_argument('out', type=str,
-		help="""Output directory to store results and intermediate files""")
-	parser.add_argument('-t', dest='threads', type=int, default=1,
-		help="""Number of CPUs to use (default=1)""")
-	parser.add_argument('-d', dest='db', type=str,
-		help="""Path to reference database
-By default, the IMAGEN_DB environmental variable is used""")
-	parser.add_argument('--pid', type=float, default=98,
-		help="""Minimum %% identity to reference (default=98)""")
-	parser.add_argument('--evalue', type=float, default=1e-5,
-		help="""Maximum evalue (default=1e-5)""")
-	parser.add_argument('--qcov', type=float, default=25,
-		help="""Minimum percent query coverage (default=25)""")
-	args = vars(parser.parse_args())
-	return args
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description="MAGpurify: known-contam module: find contigs that match a database of known contaminants",
+    )
+    parser.add_argument('program', help=argparse.SUPPRESS)
+    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument(
+        'out',
+        type=str,
+        help="""Output directory to store results and intermediate files""",
+    )
+    parser.add_argument(
+        '-t',
+        dest='threads',
+        type=int,
+        default=1,
+        help="""Number of CPUs to use (default=1)""",
+    )
+    parser.add_argument(
+        '-d',
+        dest='db',
+        type=str,
+        help="""Path to reference database
+By default, the IMAGEN_DB environmental variable is used""",
+    )
+    parser.add_argument(
+        '--pid',
+        type=float,
+        default=98,
+        help="""Minimum %% identity to reference (default=98)""",
+    )
+    parser.add_argument(
+        '--evalue', type=float, default=1e-5, help="""Maximum evalue (default=1e-5)"""
+    )
+    parser.add_argument(
+        '--qcov',
+        type=float,
+        default=25,
+        help="""Minimum percent query coverage (default=25)""",
+    )
+    args = vars(parser.parse_args())
+    return args
+
 
 def run_blastn(query, db, out, threads, qcov=25, pid=98, evalue=1e-5):
-	cmd = "blastn "
-	cmd += "-query %s " % query
-	cmd += "-db %s " % db
-	cmd += "-out %s " % out
-	cmd += "-outfmt '6 std qlen slen' "
-	cmd += "-max_target_seqs 1 "
-	cmd += "-max_hsps 1 "
-	cmd += "-qcov_hsp_perc %s " % qcov
-	cmd += "-perc_identity %s " % pid
-	cmd += "-evalue %s " % evalue
-	cmd += "-num_threads %s " % threads
-	utility.run_process(cmd)
+    cmd = "blastn "
+    cmd += "-query %s " % query
+    cmd += "-db %s " % db
+    cmd += "-out %s " % out
+    cmd += "-outfmt '6 std qlen slen' "
+    cmd += "-max_target_seqs 1 "
+    cmd += "-max_hsps 1 "
+    cmd += "-qcov_hsp_perc %s " % qcov
+    cmd += "-perc_identity %s " % pid
+    cmd += "-evalue %s " % evalue
+    cmd += "-num_threads %s " % threads
+    utility.run_process(cmd)
+
 
 def main():
-	
-	args = fetch_args()
-	
-	utility.add_tmp_dir(args)
-	utility.check_input(args)
-	utility.check_dependencies(['blastn'])
-	utility.check_database(args)
-	
-	tmp_dir = '%s/%s' % (args['out'], args['program'])
-	if not os.path.exists(args['tmp_dir']):
-		os.makedirs(args['tmp_dir'])
 
-	print ("\n## Searching database with BLASTN")
-	for target in ['hg38', 'phix']:
-		db = '%s/known-contam/%s/%s' % (args['db'], target, target)
-		out = '%s/%s.m8' % (args['tmp_dir'], target)
-		run_blastn(args['fna'], db, out, args['threads'], args['qcov'], args['pid'], args['evalue'])
+    args = fetch_args()
 
-	print ("\n## Identifying contigs with hits to db")
-	flagged = set([])
-	for target in ['hg38', 'phix']:
-		out = '%s/%s.m8' % (args['tmp_dir'], target)
-		for r in utility.parse_blast(out):
-			flagged.add(r['qname'])
-	flagged = list(flagged)
-	out = '%s/flagged_contigs' % args['tmp_dir']
-	print ("   flagged contigs: %s" % out)
-	with open(out, 'w') as f:
-		for contig in flagged:
-			f.write(contig+'\n')
+    utility.add_tmp_dir(args)
+    utility.check_input(args)
+    utility.check_dependencies(['blastn'])
+    utility.check_database(args)
 
+    tmp_dir = '%s/%s' % (args['out'], args['program'])
+    if not os.path.exists(args['tmp_dir']):
+        os.makedirs(args['tmp_dir'])
 
+    print("\n## Searching database with BLASTN")
+    for target in ['hg38', 'phix']:
+        db = '%s/known-contam/%s/%s' % (args['db'], target, target)
+        out = '%s/%s.m8' % (args['tmp_dir'], target)
+        run_blastn(
+            args['fna'],
+            db,
+            out,
+            args['threads'],
+            args['qcov'],
+            args['pid'],
+            args['evalue'],
+        )
 
+    print("\n## Identifying contigs with hits to db")
+    flagged = set([])
+    for target in ['hg38', 'phix']:
+        out = '%s/%s.m8' % (args['tmp_dir'], target)
+        for r in utility.parse_blast(out):
+            flagged.add(r['qname'])
+    flagged = list(flagged)
+    out = '%s/flagged_contigs' % args['tmp_dir']
+    print("   flagged contigs: %s" % out)
+    with open(out, 'w') as f:
+        for contig in flagged:
+            f.write(contig + '\n')
 

--- a/magpurify/csmg.py
+++ b/magpurify/csmg.py
@@ -226,12 +226,10 @@ class Bin:
 
 
 def main():
-
     args = fetch_args()
     utility.add_tmp_dir(args)
     utility.check_input(args)
     utility.check_database(args)
-
     print("\n## Reading database info")
     ref_taxonomy = read_ref_taxonomy(args['db'])
     taxon_to_taxonomy = {}
@@ -251,11 +249,9 @@ def main():
             'g': 20,
             's': 19,
         }
-
     print("\n## Calling genes with Prodigal")
     utility.run_prodigal(args['fna'], args['tmp_dir'])
     print("   all genes: %s/genes.[ffn|faa]" % args['tmp_dir'])
-
     print(
         "\n## Performing pairwise alignment of genes against MetaPhlan2 db of clade-specific genes"
     )
@@ -265,14 +261,12 @@ def main():
     print("\n## Finding top hits to db")
     genes = {}
     for aln in utility.parse_last(args['tmp_dir'] + '/genes.m8'):
-
         # clade exclusion
         ref_taxa = ref_taxonomy[aln['tid']].split('|')
         if args['exclude_clades'] and any(
             [taxon in ref_taxa for taxon in args['exclude_clades'].split(',')]
         ):
             continue
-
         # initialize gene
         if aln['qid'] not in genes:
             genes[aln['qid']] = Gene()
@@ -286,7 +280,6 @@ def main():
         elif float(aln['score']) > float(genes[aln['qid']].aln['score']):
             genes[aln['qid']].ref_taxa = ref_taxa
     print("   %s genes with a database hit" % len(genes))
-
     print("\n## Classifying genes at each taxonomic rank")
     counts = {}
     for gene in genes.values():
@@ -306,22 +299,18 @@ def main():
             counts[rank] += 1
     for rank in ranks:
         print("   %s: %s classified genes" % (rank_names[rank], counts[rank]))
-
     print("\n## Taxonomically classifying contigs")
     contigs = {}
     for id, seq in utility.parse_fasta(args['fna']):
         contigs[id] = Contig()
         contigs[id].id = id
         contigs[id].length = len(seq)
-
     # aggregate hits by contig
     for gene in genes.values():
         contigs[gene.contig_id].genes.append(gene)
-
     # classify contigs at each level
     for contig in contigs.values():
         contig.classify()
-
     # summarize
     counts = {}
     for contig in contigs.values():
@@ -345,7 +334,6 @@ def main():
         args['lowest_rank'],
     )
     print("   consensus taxon: %s" % bin.cons_taxon)
-
     print("\n## Identifying taxonomically discordant contigs")
     if bin.cons_taxon is not None:
         bin.rank_index = (

--- a/magpurify/csmg.py
+++ b/magpurify/csmg.py
@@ -1,274 +1,367 @@
 #!/usr/bin/env python
 
 import sys, os, copy, collections, operator
-import utility
+from . import utility
 import argparse
 
 ranks = ['k', 'p', 'c', 'o', 'f', 'g', 's']
-rank_names = {'k':'kingdom', 'p':'phylum', 'c':'class', 'o':'order', 'f':'family', 'g':'genus', 's':'species'}
+rank_names = {
+    'k': 'kingdom',
+    'p': 'phylum',
+    'c': 'class',
+    'o': 'order',
+    'f': 'family',
+    'g': 'genus',
+    's': 'species',
+}
+
 
 def fetch_args():
-	parser = argparse.ArgumentParser(
-		formatter_class=argparse.RawTextHelpFormatter,
-		usage=argparse.SUPPRESS,
-		description="MAGpurify: clade-markers module: find taxonomic discordant contigs using db of clade-specific marker genes"
-	)
-	parser.add_argument('program', help=argparse.SUPPRESS)
-	parser.add_argument('fna', type=str,
-		help="""Path to input genome in FASTA format""")
-	parser.add_argument('out', type=str,
-		help="""Output directory to store results and intermediate files""")
-	parser.add_argument('-t', dest='threads', type=int, default=1,
-		help="""Number of CPUs to use (default=1)""")
-	parser.add_argument('-d', dest='db', type=str,
-		help="""Path to reference database
-By default, the MAGPURIFY environmental variable is used""")
-	parser.add_argument('-e', '--exclude_clades', type=str,
-		help="""Comma separated list of clades to exclude (ex: s__Variovorax_sp_CF313)""")
-	parser.add_argument('-b', '--min_bin_fract', type=float, default=0.6,
-		help="""Min fraction of bin length supported by contigs that agree with consensus taxonomy (default=0.6)""")
-	parser.add_argument('-c', '--min_contig_fract', type=float, default=0.75,
-		help="""Min fraction of classified contig length that agree with consensus taxonomy (default=0.75)""")
-	parser.add_argument('-g', '--min_gene_fract', type=float, default=0.0,
-		help="""Min fraction of classified genes that agree with consensus taxonomy (default=0.0)""")
-	parser.add_argument('-m', '--min_genes', type=float, default=None,
-		help="""Min number of genes that agree with consensus taxonomy (default=rank-specific-cutoffs)""")
-	parser.add_argument('-l', '--lowest_rank', choices=['s','g','f','o','c','p','k'],
-		help="""Lowest rank for bin classification""")
-		
-	args = vars(parser.parse_args())
-	return args
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description="MAGpurify: clade-markers module: find taxonomic discordant contigs using db of clade-specific marker genes",
+    )
+    parser.add_argument('program', help=argparse.SUPPRESS)
+    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument(
+        'out',
+        type=str,
+        help="""Output directory to store results and intermediate files""",
+    )
+    parser.add_argument(
+        '-t',
+        dest='threads',
+        type=int,
+        default=1,
+        help="""Number of CPUs to use (default=1)""",
+    )
+    parser.add_argument(
+        '-d',
+        dest='db',
+        type=str,
+        help="""Path to reference database
+By default, the MAGPURIFY environmental variable is used""",
+    )
+    parser.add_argument(
+        '-e',
+        '--exclude_clades',
+        type=str,
+        help="""Comma separated list of clades to exclude (ex: s__Variovorax_sp_CF313)""",
+    )
+    parser.add_argument(
+        '-b',
+        '--min_bin_fract',
+        type=float,
+        default=0.6,
+        help="""Min fraction of bin length supported by contigs that agree with consensus taxonomy (default=0.6)""",
+    )
+    parser.add_argument(
+        '-c',
+        '--min_contig_fract',
+        type=float,
+        default=0.75,
+        help="""Min fraction of classified contig length that agree with consensus taxonomy (default=0.75)""",
+    )
+    parser.add_argument(
+        '-g',
+        '--min_gene_fract',
+        type=float,
+        default=0.0,
+        help="""Min fraction of classified genes that agree with consensus taxonomy (default=0.0)""",
+    )
+    parser.add_argument(
+        '-m',
+        '--min_genes',
+        type=float,
+        default=None,
+        help="""Min number of genes that agree with consensus taxonomy (default=rank-specific-cutoffs)""",
+    )
+    parser.add_argument(
+        '-l',
+        '--lowest_rank',
+        choices=['s', 'g', 'f', 'o', 'c', 'p', 'k'],
+        help="""Lowest rank for bin classification""",
+    )
+
+    args = vars(parser.parse_args())
+    return args
+
 
 def add_defaults(args):
-	args['lowest_rank'] = None
-	args['min_genes'] = None
-	args['min_gene_fract'] = 0.0
-	args['min_contig_fract'] = 0.75
-	args['min_bin_fract'] = 0.6
-	args['exclude_clades'] = None
+    args['lowest_rank'] = None
+    args['min_genes'] = None
+    args['min_gene_fract'] = 0.0
+    args['min_contig_fract'] = 0.75
+    args['min_bin_fract'] = 0.6
+    args['exclude_clades'] = None
+
 
 def read_ref_taxonomy(db_dir):
-	ref_taxonomy = {}
-	inpath = '%s/clade-markers/taxonomy.tsv' % db_dir
-	for line in open(inpath):
-		ref_id, taxonomy = line.rstrip().split()
-		ref_taxonomy[ref_id] = taxonomy
-	return ref_taxonomy
+    ref_taxonomy = {}
+    inpath = '%s/clade-markers/taxonomy.tsv' % db_dir
+    for line in open(inpath):
+        ref_id, taxonomy = line.rstrip().split()
+        ref_taxonomy[ref_id] = taxonomy
+    return ref_taxonomy
+
 
 def flag_contigs(contigs, bin):
-	for bin_taxon in bin.taxonomy:
-		bin_rank = bin_taxon.split('__')[0]
-		for contig in contigs.values():
-			contig_taxa = [gene.taxa[bin_rank] for gene in contig.genes if gene.taxa[bin_rank]]
-			# contig has no gene hits at rank
-			if len(contig_taxa) == 0:
-				continue
-			# flag contig as discordant
-			elif bin_taxon not in contig_taxa:
-				contig.flagged = True
-			# contig already flagged as discordant at higher rank
-			elif contig.flagged:
-				continue
-			# flag contig as concordant
-			# this is debatable...contig could be flagged as concordant,
-			# but at a higher rank than the bin in annotated to
-			else:
-				contig.flagged = False
+    for bin_taxon in bin.taxonomy:
+        bin_rank = bin_taxon.split('__')[0]
+        for contig in contigs.values():
+            contig_taxa = [
+                gene.taxa[bin_rank] for gene in contig.genes if gene.taxa[bin_rank]
+            ]
+            # contig has no gene hits at rank
+            if len(contig_taxa) == 0:
+                continue
+            # flag contig as discordant
+            elif bin_taxon not in contig_taxa:
+                contig.flagged = True
+            # contig already flagged as discordant at higher rank
+            elif contig.flagged:
+                continue
+            # flag contig as concordant
+            # this is debatable...contig could be flagged as concordant,
+            # but at a higher rank than the bin in annotated to
+            else:
+                contig.flagged = False
+
 
 class Gene:
-	def __init__(self):
-		self.id = None
-		self.aln = None
-		self.taxa = dict([(rank, None) for rank in ranks])
+    def __init__(self):
+        self.id = None
+        self.aln = None
+        self.taxa = dict([(rank, None) for rank in ranks])
+
 
 class Contig:
-	def __init__(self):
-		self.id = None
-		self.length = None
-		self.genes = []
-		self.flagged = None
-		self.cons_taxa = dict([(rank, None) for rank in ranks])
+    def __init__(self):
+        self.id = None
+        self.length = None
+        self.genes = []
+        self.flagged = None
+        self.cons_taxa = dict([(rank, None) for rank in ranks])
 
-	def classify(self):
-		for rank in ranks:
-			taxa = [g.taxa[rank] for g in self.genes if g.taxa[rank]]
-			if len(taxa) > 0:
-				counts = collections.Counter(taxa).items()
-				self.cons_taxa[rank] = sorted(counts, key=operator.itemgetter(1), reverse=True)[0][0]
+    def classify(self):
+        for rank in ranks:
+            taxa = [g.taxa[rank] for g in self.genes if g.taxa[rank]]
+            if len(taxa) > 0:
+                counts = collections.Counter(taxa).items()
+                self.cons_taxa[rank] = sorted(
+                    counts, key=operator.itemgetter(1), reverse=True
+                )[0][0]
+
 
 class Bin:
-	def __init__(self):
-		self.cons_taxon = None
-		self.bin_fract = None
-		self.contig_fract = None
-		self.gene_fract = None
-		self.taxonomy = [None]
-		self.tagged_length = 0
-		self.tagged_genes = 0
+    def __init__(self):
+        self.cons_taxon = None
+        self.bin_fract = None
+        self.contig_fract = None
+        self.gene_fract = None
+        self.taxonomy = [None]
+        self.tagged_length = 0
+        self.tagged_genes = 0
 
-	def classify(self, contigs, min_bin_fract, min_contig_fract, min_gene_fract, min_genes, lowest_rank):
-		
-		for rank in ranks:
-		
-			count_genes = collections.defaultdict(int)
-			for contig in contigs.values():
-				for gene in contig.genes:
-					if gene.taxa[rank]:
-						count_genes[gene.taxa[rank]] += 1
-			
-			count_length = collections.defaultdict(int)
-			for contig in contigs.values():
-				contig_taxon = contig.cons_taxa[rank]
-				if contig_taxon is not None:
-					count_length[contig_taxon] += contig.length
-			
-			if sum(count_length.values()) > 0:
-				cons_taxon = sorted(count_length.items(), key=operator.itemgetter(1), reverse=True)[0][0]
-				gene_fract = count_genes[cons_taxon]/float(sum(count_genes.values()))
-				contig_fract = count_length[cons_taxon]/float(sum(count_length.values()))
-				bin_fract = sum(count_length.values())/float(sum([c.length for c in contigs.values()]))
-			else:
-				cons_taxon = 'NA'
-				gene_fract = 0.0
-				contig_fract = 0.0
-				bin_fract = 0.0
+    def classify(
+        self,
+        contigs,
+        min_bin_fract,
+        min_contig_fract,
+        min_gene_fract,
+        min_genes,
+        lowest_rank,
+    ):
 
-			if bin_fract < min_bin_fract:
-				continue
-			elif contig_fract < min_contig_fract:
-				continue
-			elif gene_fract < min_gene_fract:
-				continue
-			elif count_genes[cons_taxon] < max(min_genes[rank], 1):
-				continue
-			else:
-				self.cons_taxon = cons_taxon
-				self.gene_fract = gene_fract
-				self.contig_fract = contig_fract
-				self.bin_fract = bin_fract
-				self.tagged_genes = sum(count_genes.values())
-				self.tagged_length = sum(count_length.values())
+        for rank in ranks:
 
-			if lowest_rank and rank == lowest_rank:
-				break
+            count_genes = collections.defaultdict(int)
+            for contig in contigs.values():
+                for gene in contig.genes:
+                    if gene.taxa[rank]:
+                        count_genes[gene.taxa[rank]] += 1
+
+            count_length = collections.defaultdict(int)
+            for contig in contigs.values():
+                contig_taxon = contig.cons_taxa[rank]
+                if contig_taxon is not None:
+                    count_length[contig_taxon] += contig.length
+
+            if sum(count_length.values()) > 0:
+                cons_taxon = sorted(
+                    count_length.items(), key=operator.itemgetter(1), reverse=True
+                )[0][0]
+                gene_fract = count_genes[cons_taxon] / float(sum(count_genes.values()))
+                contig_fract = count_length[cons_taxon] / float(
+                    sum(count_length.values())
+                )
+                bin_fract = sum(count_length.values()) / sum(
+                    c.length for c in contigs.values()
+                )
+            else:
+                cons_taxon = 'NA'
+                gene_fract = 0.0
+                contig_fract = 0.0
+                bin_fract = 0.0
+
+            if bin_fract < min_bin_fract:
+                continue
+            elif contig_fract < min_contig_fract:
+                continue
+            elif gene_fract < min_gene_fract:
+                continue
+            elif count_genes[cons_taxon] < max(min_genes[rank], 1):
+                continue
+            else:
+                self.cons_taxon = cons_taxon
+                self.gene_fract = gene_fract
+                self.contig_fract = contig_fract
+                self.bin_fract = bin_fract
+                self.tagged_genes = sum(count_genes.values())
+                self.tagged_length = sum(count_length.values())
+
+            if lowest_rank and rank == lowest_rank:
+                break
+
 
 def main():
 
-	args = fetch_args()
-	utility.add_tmp_dir(args)
-	utility.check_input(args)
-	utility.check_database(args)
+    args = fetch_args()
+    utility.add_tmp_dir(args)
+    utility.check_input(args)
+    utility.check_database(args)
 
-	print ("\n## Reading database info")
-	ref_taxonomy = read_ref_taxonomy(args['db'])
-	taxon_to_taxonomy = {}
-	for taxonomy in set(ref_taxonomy.values()):
-		for taxon in taxonomy.split('|'):
-			taxon_to_taxonomy[taxon] = taxonomy
-	min_pid = {'k':57, 'p':77, 'c':82, 'o':86, 'f':87, 'g':91, 's':96}
-	if args['min_genes'] is not None:
-		args['min_genes'] = dict([(r,args['min_genes']) for r in ranks])
-	else:
-		args['min_genes'] = {'k':237, 'p':44, 'c':30, 'o':24, 'f':22, 'g':20, 's':19}
+    print("\n## Reading database info")
+    ref_taxonomy = read_ref_taxonomy(args['db'])
+    taxon_to_taxonomy = {}
+    for taxonomy in set(ref_taxonomy.values()):
+        for taxon in taxonomy.split('|'):
+            taxon_to_taxonomy[taxon] = taxonomy
+    min_pid = {'k': 57, 'p': 77, 'c': 82, 'o': 86, 'f': 87, 'g': 91, 's': 96}
+    if args['min_genes'] is not None:
+        args['min_genes'] = dict([(r, args['min_genes']) for r in ranks])
+    else:
+        args['min_genes'] = {
+            'k': 237,
+            'p': 44,
+            'c': 30,
+            'o': 24,
+            'f': 22,
+            'g': 20,
+            's': 19,
+        }
 
-	print ("\n## Calling genes with Prodigal")
-	utility.run_prodigal(args['fna'], args['tmp_dir'])
-	print ("   all genes: %s/genes.[ffn|faa]" % args['tmp_dir'])
-	
-	print ("\n## Performing pairwise alignment of genes against MetaPhlan2 db of clade-specific genes")
-	utility.run_lastal(args['db'], args['tmp_dir'], args['threads'])
-	print ("   alignments: %s/genes.m8" % args['tmp_dir'])
+    print("\n## Calling genes with Prodigal")
+    utility.run_prodigal(args['fna'], args['tmp_dir'])
+    print("   all genes: %s/genes.[ffn|faa]" % args['tmp_dir'])
 
-	print ("\n## Finding top hits to db")
-	genes = {}
-	for aln in utility.parse_last(args['tmp_dir']+'/genes.m8'):
-	
-		# clade exclusion
-		ref_taxa = ref_taxonomy[aln['tid']].split('|')
-		if (args['exclude_clades'] and
-				any([taxon in ref_taxa for taxon in args['exclude_clades'].split(',')])):
-			continue
-		
-		# initialize gene
-		if aln['qid'] not in genes:
-			genes[aln['qid']] = Gene()
-			genes[aln['qid']].id = aln['qid']
-			genes[aln['qid']].contig_id = aln['qid'].rsplit('_',1)[0]
+    print(
+        "\n## Performing pairwise alignment of genes against MetaPhlan2 db of clade-specific genes"
+    )
+    utility.run_lastal(args['db'], args['tmp_dir'], args['threads'])
+    print("   alignments: %s/genes.m8" % args['tmp_dir'])
 
-		# get top alignments
-		if genes[aln['qid']].aln is None:
-			genes[aln['qid']].aln = aln
-			genes[aln['qid']].ref_taxa = ref_taxa
-		elif float(aln['score']) > float(genes[aln['qid']].aln['score']):
-			genes[aln['qid']].ref_taxa = ref_taxa
-	print ("   %s genes with a database hit" % len(genes))
+    print("\n## Finding top hits to db")
+    genes = {}
+    for aln in utility.parse_last(args['tmp_dir'] + '/genes.m8'):
 
-	print ("\n## Classifying genes at each taxonomic rank")
-	counts = {}
-	for gene in genes.values():
-		for ref_taxon in gene.ref_taxa:
-			rank = ref_taxon.split('__')[0]
-			if rank not in counts: counts[rank] = 0
-			if rank == 't':
-				continue
-			elif float(gene.aln['pid']) < min_pid[rank]:
-				continue
-			elif gene.aln['qcov'] < 0.4:
-				continue
-			elif gene.aln['tcov'] < 0.4:
-				continue
-			gene.taxa[rank] = ref_taxon
-			counts[rank] += 1
-	for rank in ranks:
-		print ("   %s: %s classified genes" % (rank_names[rank], counts[rank]))
+        # clade exclusion
+        ref_taxa = ref_taxonomy[aln['tid']].split('|')
+        if args['exclude_clades'] and any(
+            [taxon in ref_taxa for taxon in args['exclude_clades'].split(',')]
+        ):
+            continue
 
-	print ("\n## Taxonomically classifying contigs")
-	contigs = {}
-	for id, seq in utility.parse_fasta(args['fna']):
-		contigs[id] = Contig()
-		contigs[id].id = id
-		contigs[id].length = len(seq)
+        # initialize gene
+        if aln['qid'] not in genes:
+            genes[aln['qid']] = Gene()
+            genes[aln['qid']].id = aln['qid']
+            genes[aln['qid']].contig_id = aln['qid'].rsplit('_', 1)[0]
 
-	# aggregate hits by contig
-	for gene in genes.values():
-		contigs[gene.contig_id].genes.append(gene)
+        # get top alignments
+        if genes[aln['qid']].aln is None:
+            genes[aln['qid']].aln = aln
+            genes[aln['qid']].ref_taxa = ref_taxa
+        elif float(aln['score']) > float(genes[aln['qid']].aln['score']):
+            genes[aln['qid']].ref_taxa = ref_taxa
+    print("   %s genes with a database hit" % len(genes))
 
-	# classify contigs at each level
-	for contig in contigs.values():
-		contig.classify()
+    print("\n## Classifying genes at each taxonomic rank")
+    counts = {}
+    for gene in genes.values():
+        for ref_taxon in gene.ref_taxa:
+            rank = ref_taxon.split('__')[0]
+            if rank not in counts:
+                counts[rank] = 0
+            if rank == 't':
+                continue
+            elif float(gene.aln['pid']) < min_pid[rank]:
+                continue
+            elif gene.aln['qcov'] < 0.4:
+                continue
+            elif gene.aln['tcov'] < 0.4:
+                continue
+            gene.taxa[rank] = ref_taxon
+            counts[rank] += 1
+    for rank in ranks:
+        print("   %s: %s classified genes" % (rank_names[rank], counts[rank]))
 
-	# summarize
-	counts = {}
-	for contig in contigs.values():
-		for rank, taxon in contig.cons_taxa.items():
-			if rank not in counts:
-				counts[rank] = 0
-			if taxon is not None:
-				counts[rank] += 1
-	print ("   total contigs: %s" % len(contigs))
-	for rank in ranks:
-		print ("   %s: %s classified contigs" % (rank_names[rank], counts[rank]))
+    print("\n## Taxonomically classifying contigs")
+    contigs = {}
+    for id, seq in utility.parse_fasta(args['fna']):
+        contigs[id] = Contig()
+        contigs[id].id = id
+        contigs[id].length = len(seq)
 
-	print ("\n## Taxonomically classifying genome")
-	bin = Bin()
-	bin.classify(contigs, args['min_bin_fract'], args['min_contig_fract'],
-	             args['min_gene_fract'], args['min_genes'], args['lowest_rank'])
-	print ("   consensus taxon: %s" % bin.cons_taxon)
+    # aggregate hits by contig
+    for gene in genes.values():
+        contigs[gene.contig_id].genes.append(gene)
 
-	print ("\n## Identifying taxonomically discordant contigs")
-	if bin.cons_taxon is not None:
-		bin.rank_index = taxon_to_taxonomy[bin.cons_taxon].split('|').index(bin.cons_taxon)
-		bin.taxonomy = taxon_to_taxonomy[bin.cons_taxon].split('|')[0:bin.rank_index+1]
-		flag_contigs(contigs, bin)
-	flagged = []
-	for contig in contigs.values():
-		if contig.flagged:
-			flagged.append(contig.id)
-	out = '%s/flagged_contigs' % args['tmp_dir']
-	print ("   flagged contigs: %s" % out)
-	with open(out, 'w') as f:
-		for contig in flagged:
-			f.write(contig+'\n')
+    # classify contigs at each level
+    for contig in contigs.values():
+        contig.classify()
 
+    # summarize
+    counts = {}
+    for contig in contigs.values():
+        for rank, taxon in contig.cons_taxa.items():
+            if rank not in counts:
+                counts[rank] = 0
+            if taxon is not None:
+                counts[rank] += 1
+    print("   total contigs: %s" % len(contigs))
+    for rank in ranks:
+        print("   %s: %s classified contigs" % (rank_names[rank], counts[rank]))
 
+    print("\n## Taxonomically classifying genome")
+    bin = Bin()
+    bin.classify(
+        contigs,
+        args['min_bin_fract'],
+        args['min_contig_fract'],
+        args['min_gene_fract'],
+        args['min_genes'],
+        args['lowest_rank'],
+    )
+    print("   consensus taxon: %s" % bin.cons_taxon)
+
+    print("\n## Identifying taxonomically discordant contigs")
+    if bin.cons_taxon is not None:
+        bin.rank_index = (
+            taxon_to_taxonomy[bin.cons_taxon].split('|').index(bin.cons_taxon)
+        )
+        bin.taxonomy = taxon_to_taxonomy[bin.cons_taxon].split('|')[
+            0 : bin.rank_index + 1
+        ]
+        flag_contigs(contigs, bin)
+    flagged = []
+    for contig in contigs.values():
+        if contig.flagged:
+            flagged.append(contig.id)
+    out = '%s/flagged_contigs' % args['tmp_dir']
+    print("   flagged contigs: %s" % out)
+    with open(out, 'w') as f:
+        for contig in flagged:
+            f.write(contig + '\n')
 

--- a/magpurify/gc.py
+++ b/magpurify/gc.py
@@ -45,11 +45,9 @@ class Contig:
 
 
 def main():
-
     args = fetch_args()
     utility.add_tmp_dir(args)
     utility.check_input(args)
-
     print("\n## Computing mean genome-wide GC content")
     contigs = {}
     for id, seq in utility.parse_fasta(args['fna']):
@@ -60,14 +58,12 @@ def main():
         contigs[id] = contig
     mean = np.mean([c.gc for c in contigs.values()])
     std = np.std([c.gc for c in contigs.values()])
-
     print("\n## Computing per-contig deviation from mean")
     for contig in contigs.values():
         contig.values = {}
         contig.values['delta'] = abs(contig.gc - mean)
         contig.values['percent'] = 100 * abs(contig.gc - mean) / mean
         contig.values['z-score'] = abs(contig.gc - mean) / std
-
     print("\n## Identifying outlier contigs")
     flagged = []
     for contig in contigs.values():

--- a/magpurify/gc.py
+++ b/magpurify/gc.py
@@ -1,81 +1,81 @@
 #!/usr/bin/env python
 
 import sys
-import utility
+from . import utility
 import numpy as np
 import argparse
 import os
+from Bio import SeqUtils
+
 
 def fetch_args():
-	parser = argparse.ArgumentParser(
-		formatter_class=argparse.RawTextHelpFormatter,
-		usage=argparse.SUPPRESS,
-		description="MAGpurify: gc-content module: find contigs with outlier gc content"
-	)
-	parser.add_argument('program', help=argparse.SUPPRESS)
-	parser.add_argument('fna', type=str,
-		help="""Path to input genome in FASTA format""")
-	parser.add_argument('out', type=str,
-		help="""Output directory to store results and intermediate files""")
-	parser.add_argument('-t', dest='threads', type=int, default=1,
-		help="""Number of CPUs to use (default=1)""")
-	parser.add_argument('-d', dest='db', type=str,
-		help="""Path to reference database
-By default, the MAGPURIFY environmental variable is used""")
-	parser.add_argument('--cutoff', type=float, default=15.75,
-		help="""Cutoff (default=15.75)""")
-	args = vars(parser.parse_args())
-	return args
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description="MAGpurify: gc-content module: find contigs with outlier gc content",
+    )
+    parser.add_argument('program', help=argparse.SUPPRESS)
+    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument(
+        'out',
+        type=str,
+        help="""Output directory to store results and intermediate files""",
+    )
+    parser.add_argument(
+        '-t',
+        dest='threads',
+        type=int,
+        default=1,
+        help="""Number of CPUs to use (default=1)""",
+    )
+    parser.add_argument(
+        '--cutoff', type=float, default=15.75, help="""Cutoff (default=15.75)"""
+    )
+    args = vars(parser.parse_args())
+    return args
+
 
 def add_defaults(args):
-	args['cutoff'] = 15.75
+    args['cutoff'] = 15.75
 
-def compute_gc(dna):
-	counts = [dna.upper().count(base) for base in list('ACGT')]
-	if sum(counts) > 0:
-		return round(100*(counts[1]+counts[2])/float(sum(counts)),2)
-	else:
-		return 0.0
 
 class Contig:
-	def __init__(self):
-		pass
+    def __init__(self):
+        pass
+
 
 def main():
 
-	args = fetch_args()
-	utility.add_tmp_dir(args)
-	utility.check_input(args)
-	utility.check_database(args)
-	
-	print "\n## Computing mean genome-wide GC content"
-	contigs = {}
-	for id, seq in utility.parse_fasta(args['fna']):
-		contig = Contig()
-		contig.id = id
-		contig.seq = str(seq)
-		contig.gc = compute_gc(seq)
-		contigs[id] = contig
-	mean = np.mean([c.gc for c in contigs.values()])
-	std = np.std([c.gc for c in contigs.values()])
-	
-	print "\n## Computing per-contig deviation from mean"
-	for contig in contigs.values():
-		contig.values = {}
-		contig.values['delta'] = abs(contig.gc - mean)
-		contig.values['percent'] = 100 * abs(contig.gc - mean)/mean
-		contig.values['z-score'] = abs(contig.gc - mean)/std
-		
-	print "\n## Identifying outlier contigs"
-	flagged = []
-	for contig in contigs.values():
-		if contig.values['delta'] > args['cutoff']:
-			flagged.append(contig.id)
-	out = '%s/flagged_contigs' % args['tmp_dir']
-	print ("   flagged contigs: %s" % out)
-	with open(out, 'w') as f:
-		for contig in flagged:
-			f.write(contig+'\n')
+    args = fetch_args()
+    utility.add_tmp_dir(args)
+    utility.check_input(args)
 
+    print("\n## Computing mean genome-wide GC content")
+    contigs = {}
+    for id, seq in utility.parse_fasta(args['fna']):
+        contig = Contig()
+        contig.id = id
+        contig.seq = str(seq)
+        contig.gc = round(SeqUtils.GC(seq), 2)
+        contigs[id] = contig
+    mean = np.mean([c.gc for c in contigs.values()])
+    std = np.std([c.gc for c in contigs.values()])
 
+    print("\n## Computing per-contig deviation from mean")
+    for contig in contigs.values():
+        contig.values = {}
+        contig.values['delta'] = abs(contig.gc - mean)
+        contig.values['percent'] = 100 * abs(contig.gc - mean) / mean
+        contig.values['z-score'] = abs(contig.gc - mean) / std
+
+    print("\n## Identifying outlier contigs")
+    flagged = []
+    for contig in contigs.values():
+        if contig.values['delta'] > args['cutoff']:
+            flagged.append(contig.id)
+    out = '%s/flagged_contigs' % args['tmp_dir']
+    print("   flagged contigs: %s" % out)
+    with open(out, 'w') as f:
+        for contig in flagged:
+            f.write(contig + '\n')
 

--- a/magpurify/tetra.py
+++ b/magpurify/tetra.py
@@ -4,123 +4,132 @@ import sys, Bio.Seq
 from sklearn.decomposition import PCA
 import numpy as np
 import pandas as pd
-import utility
+from . import utility
 import argparse
 import os
 
+
 def fetch_args():
-	parser = argparse.ArgumentParser(
-		formatter_class=argparse.RawTextHelpFormatter,
-		usage=argparse.SUPPRESS,
-		description="MAGpurify: tetra-freq module: find contigs with outlier tetranucleotide frequency"
-	)
-	parser.add_argument('program', help=argparse.SUPPRESS)
-	parser.add_argument('fna', type=str,
-		help="""Path to input genome in FASTA format""")
-	parser.add_argument('out', type=str,
-		help="""Output directory to store results and intermediate files""")
-	parser.add_argument('-t', dest='threads', type=int, default=1,
-		help="""Number of CPUs to use (default=1)""")
-	parser.add_argument('-d', dest='db', type=str,
-		help="""Path to reference database
-By default, the MAGPURIFYDB environmental variable is used""")
-	parser.add_argument('--cutoff', type=float, default=0.06,
-		help="""Cutoff (default=0.06)""")
-	args = vars(parser.parse_args())
-	return args
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description="MAGpurify: tetra-freq module: find contigs with outlier tetranucleotide frequency",
+    )
+    parser.add_argument('program', help=argparse.SUPPRESS)
+    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument(
+        'out',
+        type=str,
+        help="""Output directory to store results and intermediate files""",
+    )
+    parser.add_argument(
+        '-t',
+        dest='threads',
+        type=int,
+        default=1,
+        help="""Number of CPUs to use (default=1)""",
+    )
+    parser.add_argument(
+        '--cutoff', type=float, default=0.06, help="""Cutoff (default=0.06)"""
+    )
+    args = vars(parser.parse_args())
+    return args
+
 
 def add_defaults(args):
-	args['cutoff'] = 0.06
+    args['cutoff'] = 0.06
+
 
 def init_kmers():
-	tetra = {}
-	for b1 in list('ACGT'):
-		for b2 in list('ACGT'):
-			for b3 in list('ACGT'):
-				for b4 in list('ACGT'):
-					kmer_fwd = ''.join([b1, b2, b3, b4])
-					kmer_rev = str(Bio.Seq.Seq(kmer_fwd).reverse_complement())
-					if kmer_fwd in tetra:
-						continue
-					elif kmer_rev in tetra:
-						continue
-					else:
-						tetra[kmer_fwd] = 0
-	return tetra
+    tetra = {}
+    for b1 in list('ACGT'):
+        for b2 in list('ACGT'):
+            for b3 in list('ACGT'):
+                for b4 in list('ACGT'):
+                    kmer_fwd = ''.join([b1, b2, b3, b4])
+                    kmer_rev = str(Bio.Seq.Seq(kmer_fwd).reverse_complement())
+                    if kmer_fwd in tetra:
+                        continue
+                    elif kmer_rev in tetra:
+                        continue
+                    else:
+                        tetra[kmer_fwd] = 0
+    return tetra
+
 
 class Contig:
-	def __init__(self):
-		pass
+    def __init__(self):
+        pass
+
 
 def main():
 
-	args = fetch_args()
-	utility.add_tmp_dir(args)
-	utility.check_input(args)
-	utility.check_dependencies(['blastn'])
-	utility.check_database(args)
-	
-	print "\n## Counting tetranucleotides"
-	# init data
-	kmer_counts = init_kmers()
-	contigs = {}
-	for rec in Bio.SeqIO.parse(args['fna'], 'fasta'):
-		contig = Contig()
-		contig.id = rec.id
-		contig.seq = str(rec.seq)
-		contig.kmers = kmer_counts.copy()
-		contigs[rec.id] = contig
+    args = fetch_args()
+    utility.add_tmp_dir(args)
+    utility.check_input(args)
+    utility.check_dependencies(['blastn'])
 
-	# count kmers
-	for contig in contigs.values():
-		start, stop, step = 0, 4, 1
-		while stop <= len(contig.seq):
-			kmer_fwd = contig.seq[start:stop]
-			kmer_rev = str(Bio.Seq.Seq(kmer_fwd).reverse_complement())
-			if kmer_fwd in kmer_counts:
-				contigs[rec.id].kmers[kmer_fwd] += 1
-			elif kmer_rev in kmer_counts:
-				contigs[rec.id].kmers[kmer_rev] += 1
-			start += step
-			stop += step
+    print("\n## Counting tetranucleotides")
+    # init data
+    kmer_counts = init_kmers()
+    contigs = {}
+    for rec in Bio.SeqIO.parse(args['fna'], 'fasta'):
+        contig = Contig()
+        contig.id = rec.id
+        contig.seq = str(rec.seq)
+        contig.kmers = kmer_counts.copy()
+        contigs[rec.id] = contig
 
-	print "\n## Normalizing counts"
-	for contig in contigs.values():
-		total = float(sum(contig.kmers.values()))
-		for kmer, count in contig.kmers.items():
-			if total > 0:
-				contig.kmers[kmer] = 100*count/total
-			else:
-				contig.kmers[kmer] = 0.00
+    # count kmers
+    for contig in contigs.values():
+        start, stop, step = 0, 4, 1
+        while stop <= len(contig.seq):
+            kmer_fwd = contig.seq[start:stop]
+            kmer_rev = str(Bio.Seq.Seq(kmer_fwd).reverse_complement())
+            if kmer_fwd in kmer_counts:
+                contigs[rec.id].kmers[kmer_fwd] += 1
+            elif kmer_rev in kmer_counts:
+                contigs[rec.id].kmers[kmer_rev] += 1
+            start += step
+            stop += step
 
-	print "\n## Performing PCA"
-	df = pd.DataFrame(dict([(c.id, c.kmers) for c in contigs.values()]))
-	pca = PCA(n_components=1)
-	pca.fit(df)
-	pc1 = pca.components_[0]
+    print("\n## Normalizing counts")
+    for contig in contigs.values():
+        total = float(sum(contig.kmers.values()))
+        for kmer, count in contig.kmers.items():
+            if total > 0:
+                contig.kmers[kmer] = 100 * count / total
+            else:
+                contig.kmers[kmer] = 0.00
 
-	print "\n## Computing per-contig deviation from the mean along the first principal component"
-	mean_pc = np.mean(pc1)
-	std_pc = np.std(pc1)
-	for contig_id, contig_pc in zip(list(df.columns), pc1):
-		contigs[contig_id].pc = contig_pc
-		contigs[contig_id].values = {}
-		contigs[contig_id].values['zscore'] = abs(contig_pc - mean_pc)/std_pc if std_pc > 0 else 0.0
-		contigs[contig_id].values['delta'] = abs(contig_pc - mean_pc)
-		contigs[contig_id].values['percent'] = 100*abs(contig_pc - mean_pc)/mean_pc
+    print("\n## Performing PCA")
+    df = pd.DataFrame(dict([(c.id, c.kmers) for c in contigs.values()]))
+    pca = PCA(n_components=1)
+    pca.fit(df)
+    pc1 = pca.components_[0]
 
-	print "\n## Identifying outlier contigs"
-	flagged = []
-	for contig in contigs.values():
-		if contig.values['delta'] > args['cutoff']:
-			flagged.append(contig.id)
-	out = '%s/flagged_contigs' % args['tmp_dir']
-	print ("   flagged contigs: %s" % out)
-	with open(out, 'w') as f:
-		for contig in flagged:
-			f.write(contig+'\n')
+    print(
+        "\n## Computing per-contig deviation from the mean along the first principal component"
+    )
+    mean_pc = np.mean(pc1)
+    std_pc = np.std(pc1)
+    for contig_id, contig_pc in zip(list(df.columns), pc1):
+        contigs[contig_id].pc = contig_pc
+        contigs[contig_id].values = {}
+        contigs[contig_id].values['zscore'] = (
+            abs(contig_pc - mean_pc) / std_pc if std_pc > 0 else 0.0
+        )
+        contigs[contig_id].values['delta'] = abs(contig_pc - mean_pc)
+        contigs[contig_id].values['percent'] = 100 * abs(contig_pc - mean_pc) / mean_pc
 
-
-
-
+    print("\n## Identifying outlier contigs")
+    flagged = []
+    for contig in contigs.values():
+        if contig.values['delta'] > args['cutoff']:
+            flagged.append(contig.id)
+    out = '%s/flagged_contigs' % args['tmp_dir']
+    print("   flagged contigs: %s" % out)
+    with open(out, 'w') as f:
+        for contig in flagged:
+            f.write(contig + '\n')
 

--- a/magpurify/uscmg.py
+++ b/magpurify/uscmg.py
@@ -2,409 +2,470 @@
 
 
 import os, sys, csv
-import utility
+from . import utility
 from collections import Counter
 import argparse
 
+
 def parse_args():
-	parser = argparse.ArgumentParser(
-		formatter_class=argparse.RawTextHelpFormatter,
-		usage=argparse.SUPPRESS,
-		description="MAGpurify: phylo-markers module: find taxonomic discordant contigs using db of phylogenetic marker genes"
-	)
-	parser.add_argument('program', help=argparse.SUPPRESS)
-	parser.add_argument('fna', type=str,
-		help="""Path to input genome in FASTA format""")
-	parser.add_argument('out', type=str,
-		help="""Output directory to store results and intermediate files""")
-	parser.add_argument('-t', dest='threads', type=int, default=1,
-		help="""Number of CPUs to use (default=1)""")
-	parser.add_argument('-d', dest='db', type=str,
-		help="""Path to reference database
-By default, the MAGPURIFYDB environmental variable is used""")
-	parser.add_argument('-c', dest='continue', action='store_true', default=False,
-		help="""Go straight to quality estimation and skip all previous steps""")
-	parser.add_argument('--max_target_seqs', type=int, default=1,
-		help="""Maximum number of targets reported in BLAST table (default=1)""")
-	parser.add_argument('--cutoff_type', choices=['strict', 'sensitive', 'none'], default='strict',
-		help="""Use strict or sensitive %%ID cutoff for taxonomically annotating genes (default=strict)""")
-	parser.add_argument('--seq_type', choices=['dna', 'protein', 'both', 'either'], default='protein',
-		help="""Choose to search genes versus DNA or protein database (default=protein)""")
-	parser.add_argument('--hit_type', choices=['all_hits', 'top_hit'], default='top_hit',
-		help="""Transfer taxonomy of all hits or top hit per gene (default=top_hit)""")
-	parser.add_argument('--exclude_clades', type=str,
-		help="""Comma separated list of clades to exclude (ex: s__1300164.4)""")
-	parser.add_argument('--bin_fract', type=float, default=0.7,
-		help="""Min fraction of genes in bin that agree with consensus taxonomy for bin annotation (default=0.7)""")
-	parser.add_argument('--contig_fract', type=float, default=1.0,
-		help="""Min fraction of genes in that disagree with bin taxonomy for filtering (default=1.0)""")
-	parser.add_argument('--allow_noclass', action='store_true', default=False,
-		help="""Allow a bin to be unclassfied and flag any classified contigs (default=False)""")
-	args = vars(parser.parse_args())
-	return args
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description="MAGpurify: phylo-markers module: find taxonomic discordant contigs using db of phylogenetic marker genes",
+    )
+    parser.add_argument('program', help=argparse.SUPPRESS)
+    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument(
+        'out',
+        type=str,
+        help="""Output directory to store results and intermediate files""",
+    )
+    parser.add_argument(
+        '-t',
+        dest='threads',
+        type=int,
+        default=1,
+        help="""Number of CPUs to use (default=1)""",
+    )
+    parser.add_argument(
+        '-d',
+        dest='db',
+        type=str,
+        help="""Path to reference database
+By default, the MAGPURIFYDB environmental variable is used""",
+    )
+    parser.add_argument(
+        '-c',
+        dest='continue',
+        action='store_true',
+        default=False,
+        help="""Go straight to quality estimation and skip all previous steps""",
+    )
+    parser.add_argument(
+        '--max_target_seqs',
+        type=int,
+        default=1,
+        help="""Maximum number of targets reported in BLAST table (default=1)""",
+    )
+    parser.add_argument(
+        '--cutoff_type',
+        choices=['strict', 'sensitive', 'none'],
+        default='strict',
+        help="""Use strict or sensitive %%ID cutoff for taxonomically annotating genes (default=strict)""",
+    )
+    parser.add_argument(
+        '--seq_type',
+        choices=['dna', 'protein', 'both', 'either'],
+        default='protein',
+        help="""Choose to search genes versus DNA or protein database (default=protein)""",
+    )
+    parser.add_argument(
+        '--hit_type',
+        choices=['all_hits', 'top_hit'],
+        default='top_hit',
+        help="""Transfer taxonomy of all hits or top hit per gene (default=top_hit)""",
+    )
+    parser.add_argument(
+        '--exclude_clades',
+        type=str,
+        help="""Comma separated list of clades to exclude (ex: s__1300164.4)""",
+    )
+    parser.add_argument(
+        '--bin_fract',
+        type=float,
+        default=0.7,
+        help="""Min fraction of genes in bin that agree with consensus taxonomy for bin annotation (default=0.7)""",
+    )
+    parser.add_argument(
+        '--contig_fract',
+        type=float,
+        default=1.0,
+        help="""Min fraction of genes in that disagree with bin taxonomy for filtering (default=1.0)""",
+    )
+    parser.add_argument(
+        '--allow_noclass',
+        action='store_true',
+        default=False,
+        help="""Allow a bin to be unclassfied and flag any classified contigs (default=False)""",
+    )
+    args = vars(parser.parse_args())
+    return args
+
 
 def extract_homologs(tmp_dir):
-	# create outdir
-	seqs_dir = "%s/markers" % tmp_dir
-	if not os.path.isdir(seqs_dir):
-		os.makedirs(seqs_dir)
-	# fetch best hits from hmmsearch
-	gene_to_aln = utility.fetch_hmm_best_hits("%s/phyeco.hmmsearch" % tmp_dir)
-	# open output files
-	outfiles = {}
-	marker_ids = set([aln['qacc'] for aln in gene_to_aln.values()])
-	for marker_id in marker_ids:
-		outfiles[marker_id] = {}
-		outfiles[marker_id]['ffn'] = open("%s/%s.ffn" % (seqs_dir, marker_id), "w")
-		outfiles[marker_id]['faa'] = open("%s/%s.faa" % (seqs_dir, marker_id), "w")
-	# write seqs
-	for ext in ['ffn', 'faa']:
-		in_path = "%s/genes.%s" % (tmp_dir, ext)
-		for id, seq in utility.parse_fasta(in_path):
-			if id in gene_to_aln:
-				marker_id = gene_to_aln[id]['qacc']
-				seq = seq.upper().rstrip('*')
-				outfiles[marker_id][ext].write('>'+id+'\n'+seq+'\n')
-	# close files
-	for marker_id in outfiles:
-		outfiles[marker_id]['ffn'].close()
-		outfiles[marker_id]['faa'].close()
+    # create outdir
+    seqs_dir = "%s/markers" % tmp_dir
+    if not os.path.isdir(seqs_dir):
+        os.makedirs(seqs_dir)
+    # fetch best hits from hmmsearch
+    gene_to_aln = utility.fetch_hmm_best_hits("%s/phyeco.hmmsearch" % tmp_dir)
+    # open output files
+    outfiles = {}
+    marker_ids = set([aln['qacc'] for aln in list(gene_to_aln.values())])
+    for marker_id in marker_ids:
+        outfiles[marker_id] = {}
+        outfiles[marker_id]['ffn'] = open("%s/%s.ffn" % (seqs_dir, marker_id), "w")
+        outfiles[marker_id]['faa'] = open("%s/%s.faa" % (seqs_dir, marker_id), "w")
+    # write seqs
+    for ext in ['ffn', 'faa']:
+        in_path = "%s/genes.%s" % (tmp_dir, ext)
+        for id, seq in utility.parse_fasta(in_path):
+            if id in gene_to_aln:
+                marker_id = gene_to_aln[id]['qacc']
+                seq = seq.rstrip('*')
+                outfiles[marker_id][ext].write('>' + id + '\n' + seq + '\n')
+    # close files
+    for marker_id in outfiles:
+        outfiles[marker_id]['ffn'].close()
+        outfiles[marker_id]['faa'].close()
+
 
 def align_homologs(db_dir, tmp_dir, seq_type, threads):
-	aln_dir = "%s/alns" % tmp_dir
-	if not os.path.exists(aln_dir):
-		os.makedirs(aln_dir)
-	seq_files = os.listdir("%s/markers" % tmp_dir)
-	for file_index, seq_file in enumerate(seq_files):
-		marker_id, ext = seq_file.split('.')
-		if ext == 'ffn' and seq_type == 'protein':
-			continue
-		elif ext == 'faa' and seq_type == 'dna':
-			continue
-		if ext == 'faa':
-			program = 'blastp' if ext == 'faa' else 'blastn'
-			db_path = '%s/phylo-markers/%s/%s' % (db_dir, program, marker_id)
-			query_path = '%s/markers/%s.%s' % (tmp_dir, marker_id, ext)
-			out_path = '%s/alns/%s.%s.m8' % (tmp_dir, marker_id, ext)
-			utility.run_blastp(db_path, query_path, out_path, threads)
-		else:
-			program = 'blastn'
-			db_path = '%s/phylo-markers/%s/%s' % (db_dir, program, marker_id)
-			query_path = '%s/markers/%s.%s' % (tmp_dir, marker_id, ext)
-			out_path = '%s/alns/%s.%s.m8' % (tmp_dir, marker_id, ext)
-			utility.run_blastp(db_path, query_path, out_path, threads)
+    aln_dir = "%s/alns" % tmp_dir
+    if not os.path.exists(aln_dir):
+        os.makedirs(aln_dir)
+    seq_files = os.listdir("%s/markers" % tmp_dir)
+    for file_index, seq_file in enumerate(seq_files):
+        marker_id, ext = seq_file.split('.')
+        if ext == 'ffn' and seq_type == 'protein':
+            continue
+        elif ext == 'faa' and seq_type == 'dna':
+            continue
+        if ext == 'faa':
+            program = 'blastp' if ext == 'faa' else 'blastn'
+            db_path = '%s/phylo-markers/%s/%s' % (db_dir, program, marker_id)
+            query_path = '%s/markers/%s.%s' % (tmp_dir, marker_id, ext)
+            out_path = '%s/alns/%s.%s.m8' % (tmp_dir, marker_id, ext)
+            utility.run_blastp(db_path, query_path, out_path, threads)
+        else:
+            program = 'blastn'
+            db_path = '%s/phylo-markers/%s/%s' % (db_dir, program, marker_id)
+            query_path = '%s/markers/%s.%s' % (tmp_dir, marker_id, ext)
+            out_path = '%s/alns/%s.%s.m8' % (tmp_dir, marker_id, ext)
+            utility.run_blastp(db_path, query_path, out_path, threads)
+
 
 class Bin:
-	def __init__(self):
-		self.cons_taxon = None
-		self.cons_fract = None
-		self.cons_count = None
-		self.genes = None
-	
-	def exclude_clades(self, clades):
-	
-		# loop over genes in bin
-		for gene in self.genes.values():
+    def __init__(self):
+        self.cons_taxon = None
+        self.cons_fract = None
+        self.cons_count = None
+        self.genes = None
 
-			# keep track of which annotations to exclude for each gene
-			exclude_indexes = []
-			
-			# loop over annotations for each gene
-			for index, annotation in enumerate(gene.annotations):
-				is_match = any([c in annotation.taxon for c in clades.split(',')])
-				if is_match:
-					exclude_indexes.append(index)
-			
-			# delete annotations
-			for index in exclude_indexes[::-1]:
-				del gene.annotations[index]
-	
-	def only_keep_top_hits(self):
-		for gene in self.genes.values():
-			if len(gene.annotations) > 1:
-				max_score = max([a.score for a in gene.annotations])
-				gene.annotations = [a for a in gene.annotations if a.score == max_score]
-	
-	def classify_taxonomy(self, allow_noclass=False, min_fraction=0.5):
-		"""
+    def exclude_clades(self, clades):
+
+        # loop over genes in bin
+        for gene in list(self.genes.values()):
+
+            # keep track of which annotations to exclude for each gene
+            exclude_indexes = []
+
+            # loop over annotations for each gene
+            for index, annotation in enumerate(gene.annotations):
+                is_match = any([c in annotation.taxon for c in clades.split(',')])
+                if is_match:
+                    exclude_indexes.append(index)
+
+            # delete annotations
+            for index in exclude_indexes[::-1]:
+                del gene.annotations[index]
+
+    def only_keep_top_hits(self):
+        for gene in list(self.genes.values()):
+            if len(gene.annotations) > 1:
+                max_score = max([a.score for a in gene.annotations])
+                gene.annotations = [a for a in gene.annotations if a.score == max_score]
+
+    def classify_taxonomy(self, allow_noclass=False, min_fraction=0.5):
+        """
 		determine taxon and rank of bin based on lowest rank
 		where at least <min_fraction> of genes match the consensus annotation
 		"""
-		ranks = ['s','g','f','o','c','p']
-		for rank_index, rank in enumerate(ranks):
-			
-			# get list of taxa across all genes
-			# never count a taxon 2x per gene
-			gene_taxa = []
-			for gene in self.genes.values():
-				# do not count unclassified
-				if not allow_noclass:
-					taxa = list(set([a.taxon[rank_index] for a in gene.annotations if a.taxon[rank_index]]))
-				# count unclassified
-				else:
-					taxa = list(set([a.taxon[rank_index] for a in gene.annotations]))
-				gene_taxa += taxa
+        ranks = ['s', 'g', 'f', 'o', 'c', 'p']
+        for rank_index, rank in enumerate(ranks):
 
-			# skip rank where there are no annotations
-			if len(gene_taxa) == 0:
-				continue
+            # get list of taxa across all genes
+            # never count a taxon 2x per gene
+            gene_taxa = []
+            for gene in list(self.genes.values()):
+                # do not count unclassified
+                if not allow_noclass:
+                    taxa = list(
+                        set(
+                            [
+                                a.taxon[rank_index]
+                                for a in gene.annotations
+                                if a.taxon[rank_index]
+                            ]
+                        )
+                    )
+                # count unclassified
+                else:
+                    taxa = list(set([a.taxon[rank_index] for a in gene.annotations]))
+                gene_taxa += taxa
 
-			# get most common annotation
-			cons_taxon, cons_count = Counter(gene_taxa).most_common()[0]
+            # skip rank where there are no annotations
+            if len(gene_taxa) == 0:
+                continue
 
-			# determine if enough genes have consensus annotation
-			cons_fract = cons_count/float(len(self.genes))
-			if cons_fract >= min_fraction:
-				self.cons_taxon = cons_taxon
-				self.cons_fract = cons_fract
-				self.cons_count = cons_count
-				self.rank = rank
-				self.rank_index = rank_index
-				return
+            # get most common annotation
+            cons_taxon, cons_count = Counter(gene_taxa).most_common()[0]
+
+            # determine if enough genes have consensus annotation
+            cons_fract = cons_count / float(len(self.genes))
+            if cons_fract >= min_fraction:
+                self.cons_taxon = cons_taxon
+                self.cons_fract = cons_fract
+                self.cons_count = cons_count
+                self.rank = rank
+                self.rank_index = rank_index
+                return
+
 
 class Marker:
-	def __init__(self):
-		self.id = None
+    def __init__(self):
+        self.id = None
+
 
 class Gene:
-	def __init__(self):
-		self.id = None
-		self.marker = None
-		self.contig = None
-		self.annotations = []
+    def __init__(self):
+        self.id = None
+        self.marker = None
+        self.contig = None
+        self.annotations = []
+
 
 class Annotation:
-	def __init__(self):
-		self.taxon = [None]*6
-		self.score = None
-	
-	def add_taxon(self, genome_taxon, rank_index):
-		for i in range(rank_index, 6):
-			self.taxon[i] = genome_taxon.split(';')[i]
+    def __init__(self):
+        self.taxon = [None] * 6
+        self.score = None
+
+    def add_taxon(self, genome_taxon, rank_index):
+        for i in range(rank_index, 6):
+            self.taxon[i] = genome_taxon.split(';')[i]
+
 
 class Contig:
-	def __init__(self):
-		self.id = None
-		self.genes = []
-		self.genes_agree = 0
-		self.genes_conflict = 0
-		self.flagged = None
-	
-	def compare_taxonomy(self, bin):
-		for gene in self.genes:
-			agrees = []
-			for annotation in gene.annotations:
-				agrees.append(bin.cons_taxon == annotation.taxon[bin.rank_index])
-			if any(agrees):
-				self.genes_agree += 1
-			else:
-				self.genes_conflict += 1
+    def __init__(self):
+        self.id = None
+        self.genes = []
+        self.genes_agree = 0
+        self.genes_conflict = 0
+        self.flagged = None
 
-	def flag(self, min_fract):
-		if len(self.genes) == 0:
-			self.flagged = None
-		elif self.genes_conflict/float(len(self.genes)) >= min_fract:
-			self.flagged = True
-		else:
-			self.flagged = False
+    def compare_taxonomy(self, bin):
+        for gene in self.genes:
+            agrees = []
+            for annotation in gene.annotations:
+                agrees.append(bin.cons_taxon == annotation.taxon[bin.rank_index])
+            if any(agrees):
+                self.genes_agree += 1
+            else:
+                self.genes_conflict += 1
+
+    def flag(self, min_fract):
+        if len(self.genes) == 0:
+            self.flagged = None
+        elif self.genes_conflict / float(len(self.genes)) >= min_fract:
+            self.flagged = True
+        else:
+            self.flagged = False
+
 
 def flag_contigs(db_dir, tmp_dir, args):
-	
-	# step 0. read in reference data files
-	# cutoffs
-	cutoffs = {}
-	cutoffs_path = '%s/phylo-markers/max_fscores.tsv' % db_dir
-	reader = csv.DictReader(open(cutoffs_path), delimiter="\t")
-	for r in reader:
-		key = (r['marker_id'], r['seq_type'], r['score_type'], r['taxlevel'])
-		value = {'sensitive':r['cutoff_lower'], 'strict':r['cutoff_upper'], 'none':0.0}
-		cutoffs[key] = value
-	# taxonomy
-	taxonomy = {}
-	taxonomy_path = '%s/phylo-markers/genome_taxonomy.tsv' % db_dir
-	reader = csv.DictReader(open(taxonomy_path), delimiter="\t")
-	for r in reader:
-		taxonomy[r['genome_id']] = r['taxonomy']
-	# clustered seqs
-	clusters = {}
-	for type in ['ffn', 'faa']:
-		clusters[type] = {}
-		for file in os.listdir('%s/phylo-markers/%s' % (db_dir, type)):
-			if file.split('.')[-1] == 'uc':
-				with open('%s/phylo-markers/%s/%s' % (db_dir, type, file)) as f:
-					for l in f:
-						v = l.rstrip().split()
-						rep_id = v[-1]
-						seq_id = v[-2]
-						if v[0] == 'S':
-							clusters[type][seq_id] = [seq_id]
-						elif v[0] == 'H':
-							clusters[type][rep_id].append(seq_id)
 
-	# step 1. determine if bin is archaea or bacteria; initialize domain-level markers
-	# to do: normalize counts by site of marker gene sets
-	marker_ids = set([])
-	counts = {'bacteria':0, 'archaea':0}
-	for aln_file in os.listdir('%s/alns' % tmp_dir):
-		marker_id, seq_type, ext = aln_file.split(".")
-		marker_ids.add(marker_id)
-	for marker_id in marker_ids:
-		if 'B' in marker_id:
-			counts['bacteria'] += 1
-		elif 'A' in marker_id:
-			counts['archaea'] += 1
-	domain = 'bacteria' if counts['bacteria'] >= counts['archaea'] else 'archaea'
-	markers = {}
-	for marker_id in marker_ids:
-		if domain == 'bacteria' and 'B' in marker_id:
-			markers[marker_id] = Marker()
-			markers[marker_id].id = marker_id
-			markers[marker_id].genes = []
-		elif domain == 'archaea' and 'A' in marker_id:
-			markers[marker_id] = Marker()
-			markers[marker_id].id = marker_id
-			markers[marker_id].genes = []
+    # step 0. read in reference data files
+    # cutoffs
+    cutoffs = {}
+    cutoffs_path = '%s/phylo-markers/max_fscores.tsv' % db_dir
+    reader = csv.DictReader(open(cutoffs_path), delimiter="\t")
+    for r in reader:
+        key = (r['marker_id'], r['seq_type'], r['score_type'], r['taxlevel'])
+        value = {'sensitive': r['cutoff_lower'], 'strict': r['cutoff_upper'], 'none': 0.0}
+        cutoffs[key] = value
+    # taxonomy
+    taxonomy = {}
+    taxonomy_path = '%s/phylo-markers/genome_taxonomy.tsv' % db_dir
+    reader = csv.DictReader(open(taxonomy_path), delimiter="\t")
+    for r in reader:
+        taxonomy[r['genome_id']] = r['taxonomy']
+    # clustered seqs
+    clusters = {}
+    for type in ['ffn', 'faa']:
+        clusters[type] = {}
+        for file in os.listdir('%s/phylo-markers/%s' % (db_dir, type)):
+            if file.split('.')[-1] == 'uc':
+                with open('%s/phylo-markers/%s/%s' % (db_dir, type, file)) as f:
+                    for l in f:
+                        v = l.rstrip().split()
+                        rep_id = v[-1]
+                        seq_id = v[-2]
+                        if v[0] == 'S':
+                            clusters[type][seq_id] = [seq_id]
+                        elif v[0] == 'H':
+                            clusters[type][rep_id].append(seq_id)
 
-	# step 2. initialize marker genes found in bin
-	bin = Bin()
-	bin.genes = {}
-	hmm_path = "%s/phyeco.hmmsearch" % tmp_dir
-	for gene_id, aln in utility.fetch_hmm_best_hits(hmm_path).items():
-		if aln['qacc'] not in markers:
-			continue
-		gene = Gene()
-		gene.id = gene_id
-		gene.contig = gene_id.rsplit('_', 1)[0]
-		gene.marker = aln['qacc']
-		bin.genes[gene_id] = gene
-		markers[aln['qacc']].genes.append(gene)
+    # step 1. determine if bin is archaea or bacteria; initialize domain-level markers
+    # to do: normalize counts by site of marker gene sets
+    marker_ids = set([])
+    counts = {'bacteria': 0, 'archaea': 0}
+    for aln_file in os.listdir('%s/alns' % tmp_dir):
+        marker_id, seq_type, ext = aln_file.split(".")
+        marker_ids.add(marker_id)
+    for marker_id in marker_ids:
+        if 'B' in marker_id:
+            counts['bacteria'] += 1
+        elif 'A' in marker_id:
+            counts['archaea'] += 1
+    domain = 'bacteria' if counts['bacteria'] >= counts['archaea'] else 'archaea'
+    markers = {}
+    for marker_id in marker_ids:
+        if domain == 'bacteria' and 'B' in marker_id:
+            markers[marker_id] = Marker()
+            markers[marker_id].id = marker_id
+            markers[marker_id].genes = []
+        elif domain == 'archaea' and 'A' in marker_id:
+            markers[marker_id] = Marker()
+            markers[marker_id].id = marker_id
+            markers[marker_id].genes = []
 
-	# annotate genes
-	#    fetch all non-redundant taxonomic annotations for each gene
-	seq_types = None
-	if args['seq_type'] in ['both', 'either']:
-		seq_types = ['ffn', 'faa']
-	elif args['seq_type'] == 'protein':
-		seq_types = ['faa']
-	else:
-		seq_types = ['ffn']
+    # step 2. initialize marker genes found in bin
+    bin = Bin()
+    bin.genes = {}
+    hmm_path = "%s/phyeco.hmmsearch" % tmp_dir
+    for gene_id, aln in list(utility.fetch_hmm_best_hits(hmm_path).items()):
+        if aln['qacc'] not in markers:
+            continue
+        gene = Gene()
+        gene.id = gene_id
+        gene.contig = gene_id.rsplit('_', 1)[0]
+        gene.marker = aln['qacc']
+        bin.genes[gene_id] = gene
+        markers[aln['qacc']].genes.append(gene)
 
-	for seq_type in seq_types:
-		for marker_id in markers:
-			aln_path = tmp_dir+"/alns/"+marker_id+"."+seq_type+".m8"
-			for aln in utility.parse_blast(aln_path):
-		
-				# fetch all unique taxonomies for target sequence
-				# a sequence can have multiple taxonomies if it was clustered with another sequence
-				genome_taxa = []
-				for target_id in clusters[seq_type][aln['tname']]:
-					genome_id = target_id.split('_')[0]
-					if genome_id not in taxonomy:
-						continue
-					elif taxonomy[genome_id] in genome_taxa:
-						continue
-					else:
-						genome_taxa.append(taxonomy[genome_id])
-				
-				# loop over ranks; stop when gene has been annotated
-				for rank_index, rank in enumerate(['s','g','f','o','c','p']):
-					
-					# decide to use ffn or faa at species level
-					if args['seq_type'] == 'either':
-						if seq_type == 'ffn' and rank != 's':
-							continue
-						elif seq_type == 'faa' and rank == 's':
-							continue
-					
-					# get minimum % identity cutoff for transfering taxonomy
-					#   if cutoff_type is None, indicates that no cutoff should be used
-					min_pid = cutoffs[marker_id, seq_type, 'pid', rank][args['cutoff_type']]
+    # annotate genes
+    #    fetch all non-redundant taxonomic annotations for each gene
+    seq_types = None
+    if args['seq_type'] in ['both', 'either']:
+        seq_types = ['ffn', 'faa']
+    elif args['seq_type'] == 'protein':
+        seq_types = ['faa']
+    else:
+        seq_types = ['ffn']
 
-					if float(aln['pid']) < float(min_pid):
-						continue
-					
-					# add taxonomy
-					for genome_taxon in genome_taxa:
-						annotation = Annotation()
-						annotation.add_taxon(genome_taxon, rank_index)
-						annotation.score = float(aln['bitscore'])
-						bin.genes[aln['qname']].annotations.append(annotation)
-					
-					# stop when gene has been annotated at lowest rank
-					break
+    for seq_type in seq_types:
+        for marker_id in markers:
+            aln_path = tmp_dir + "/alns/" + marker_id + "." + seq_type + ".m8"
+            for aln in utility.parse_blast(aln_path):
 
-	# optionally remove annotations matching <exclude_clades>
-	if args['exclude_clades'] is not None:
-		bin.exclude_clades(args['exclude_clades'])
+                # fetch all unique taxonomies for target sequence
+                # a sequence can have multiple taxonomies if it was clustered with another sequence
+                genome_taxa = []
+                for target_id in clusters[seq_type][aln['tname']]:
+                    genome_id = target_id.split('_')[0]
+                    if genome_id not in taxonomy:
+                        continue
+                    elif taxonomy[genome_id] in genome_taxa:
+                        continue
+                    else:
+                        genome_taxa.append(taxonomy[genome_id])
 
-	# optionally take top hit only
-	if args['hit_type'] == 'top_hit':
-		bin.only_keep_top_hits()
+                # loop over ranks; stop when gene has been annotated
+                for rank_index, rank in enumerate(['s', 'g', 'f', 'o', 'c', 'p']):
 
-	# create None annotations for unannotated genes
-	for gene in bin.genes.values():
-		if len(gene.annotations) == 0:
-			gene.annotations.append(Annotation())
+                    # decide to use ffn or faa at species level
+                    if args['seq_type'] == 'either':
+                        if seq_type == 'ffn' and rank != 's':
+                            continue
+                        elif seq_type == 'faa' and rank == 's':
+                            continue
 
-	# classify bin
-	bin.classify_taxonomy(args['allow_noclass'], args['bin_fract'])
-	
-	# flag contigs with discrepant taxonomy
-	bin.contigs = {}
-	for id, seq in utility.parse_fasta(args['fna']):
-		bin.contigs[id] = Contig()
-		bin.contigs[id].id = id
-		bin.contigs[id].length = len(seq)
+                    # get minimum % identity cutoff for transfering taxonomy
+                    #   if cutoff_type is None, indicates that no cutoff should be used
+                    min_pid = cutoffs[marker_id, seq_type, 'pid', rank][
+                        args['cutoff_type']
+                    ]
 
-	for gene in bin.genes.values():
-		bin.contigs[gene.contig].genes.append(gene)
+                    if float(aln['pid']) < float(min_pid):
+                        continue
 
-	if bin.cons_taxon is not None:
-		for contig in bin.contigs.values():
-			contig.compare_taxonomy(bin)
-			contig.flag(args['contig_fract'])
+                    # add taxonomy
+                    for genome_taxon in genome_taxa:
+                        annotation = Annotation()
+                        annotation.add_taxon(genome_taxon, rank_index)
+                        annotation.score = float(aln['bitscore'])
+                        bin.genes[aln['qname']].annotations.append(annotation)
 
-	# write results
-	flagged_contigs = []
-	for contig in bin.contigs.values():
-		if contig.flagged:
-			flagged_contigs.append(contig.id)
+                    # stop when gene has been annotated at lowest rank
+                    break
 
-	return flagged_contigs
+    # optionally remove annotations matching <exclude_clades>
+    if args['exclude_clades'] is not None:
+        bin.exclude_clades(args['exclude_clades'])
+
+    # optionally take top hit only
+    if args['hit_type'] == 'top_hit':
+        bin.only_keep_top_hits()
+
+    # create None annotations for unannotated genes
+    for gene in bin.genes.values():
+        if len(gene.annotations) == 0:
+            gene.annotations.append(Annotation())
+
+    # classify bin
+    bin.classify_taxonomy(args['allow_noclass'], args['bin_fract'])
+
+    # flag contigs with discrepant taxonomy
+    bin.contigs = {}
+    for id, seq in utility.parse_fasta(args['fna']):
+        bin.contigs[id] = Contig()
+        bin.contigs[id].id = id
+        bin.contigs[id].length = len(seq)
+
+    for gene in bin.genes.values():
+        bin.contigs[gene.contig].genes.append(gene)
+
+    if bin.cons_taxon is not None:
+        for contig in bin.contigs.values():
+            contig.compare_taxonomy(bin)
+            contig.flag(args['contig_fract'])
+
+    # write results
+    flagged_contigs = []
+    for contig in bin.contigs.values():
+        if contig.flagged:
+            flagged_contigs.append(contig.id)
+
+    return flagged_contigs
+
 
 def main():
 
-	args = parse_args()
-	utility.add_tmp_dir(args)
-	utility.check_input(args)
-	utility.check_dependencies(['prodigal', 'hmmsearch', 'blastp', 'blastn'])
-	utility.check_database(args)
-	
-	print ("\n## Calling genes with Prodigal")
-	utility.run_prodigal(args['fna'], args['tmp_dir'])
-	print ("   all genes: %s/genes.[ffn|faa]" % args['tmp_dir'])
+    args = parse_args()
+    utility.add_tmp_dir(args)
+    utility.check_input(args)
+    utility.check_dependencies(['prodigal', 'hmmsearch', 'blastp', 'blastn'])
+    utility.check_database(args)
 
-	print ("\n## Identifying PhyEco phylogenetic marker genes with HMMER")
-	utility.run_hmmsearch(args['db'], args['tmp_dir'], args['tmp_dir'], args['threads'])
-	extract_homologs(args['tmp_dir'])
-	print ("   hmm results: %s/phyeco.hmmsearch" % args['tmp_dir'])
-	print ("   marker genes: %s/markers" % args['tmp_dir'])
-	
-	print ("\n## Performing pairwise BLAST alignment of marker genes against database")
-	align_homologs(args['db'], args['tmp_dir'], args['seq_type'], args['threads'])
-	print ("   blast results: %s/alns" % args['tmp_dir'])
+    print("\n## Calling genes with Prodigal")
+    utility.run_prodigal(args['fna'], args['tmp_dir'])
+    print("   all genes: %s/genes.[ffn|faa]" % args['tmp_dir'])
 
-	print ("\n## Finding taxonomic outliers")
-	flagged = flag_contigs(args['db'], args['tmp_dir'], args)
-	out = '%s/flagged_contigs' % args['tmp_dir']
-	print ("   flagged contigs: %s" % out)
-	with open(out, 'w') as f:
-		for contig in flagged:
-			f.write(contig+'\n')
+    print("\n## Identifying PhyEco phylogenetic marker genes with HMMER")
+    utility.run_hmmsearch(args['db'], args['tmp_dir'], args['tmp_dir'], args['threads'])
+    extract_homologs(args['tmp_dir'])
+    print("   hmm results: %s/phyeco.hmmsearch" % args['tmp_dir'])
+    print("   marker genes: %s/markers" % args['tmp_dir'])
 
+    print("\n## Performing pairwise BLAST alignment of marker genes against database")
+    align_homologs(args['db'], args['tmp_dir'], args['seq_type'], args['threads'])
+    print("   blast results: %s/alns" % args['tmp_dir'])
 
-
-
-
-
+    print("\n## Finding taxonomic outliers")
+    flagged = flag_contigs(args['db'], args['tmp_dir'], args)
+    out = '%s/flagged_contigs' % args['tmp_dir']
+    print("   flagged contigs: %s" % out)
+    with open(out, 'w') as f:
+        for contig in flagged:
+            f.write(contig + '\n')
 

--- a/magpurify/utility.py
+++ b/magpurify/utility.py
@@ -1,5 +1,6 @@
 import sys, os
 from Bio import SeqIO
+import subprocess as sp
 
 
 def add_tmp_dir(args):
@@ -50,8 +51,6 @@ def check_database(args):
 
 def run_process(command):
     """ Capture stdout, stderr. Check unix exit code and exit if non-zero """
-    import subprocess as sp
-
     process = sp.Popen(command, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
     out, err = process.communicate()
     if process.returncode != 0:

--- a/magpurify/utility.py
+++ b/magpurify/utility.py
@@ -1,201 +1,277 @@
+import sys, os
+from Bio import SeqIO
 
-import sys, os, Bio.SeqIO
 
 def add_tmp_dir(args):
-	tmp_dir = '%s/%s' % (args['out'], args['program'])
-	if not os.path.exists(tmp_dir):
-		os.makedirs(tmp_dir)
-	args['tmp_dir'] = tmp_dir
+    tmp_dir = '%s/%s' % (args['out'], args['program'])
+    if not os.path.exists(tmp_dir):
+        os.makedirs(tmp_dir)
+    args['tmp_dir'] = tmp_dir
+
 
 def check_input(args):
-	if not os.path.exists(args['fna']):
-		error = "\nInput file not found: %s\n" % args['fna']
-		sys.exit(error)
-	
+    if not os.path.exists(args['fna']):
+        error = "\nInput file not found: %s\n" % args['fna']
+        sys.exit(error)
+
+
 def check_dependencies(programs):
-	for program in programs:
-		if not exists_on_env_path(program):
-			error = "\nRequired program '%s' not found\n" % program
-			error += "Make sure this program has been installed and added to your PATH\n"
-			sys.exit(error)
+    for program in programs:
+        if not exists_on_env_path(program):
+            error = "\nRequired program '%s' not found\n" % program
+            error += "Make sure this program has been installed and added to your PATH\n"
+            sys.exit(error)
+
 
 def exists_on_env_path(program):
-	""" Check whether program exists in PATH and is executable """
-	for dir in os.environ["PATH"].split(os.pathsep):
-		fpath = dir+'/'+program
-		if (os.path.exists(fpath) and
-				os.access(fpath, os.X_OK)):
-			return True
-	return False
+    """ Check whether program exists in PATH and is executable """
+    for dir in os.environ["PATH"].split(os.pathsep):
+        fpath = dir + '/' + program
+        if os.path.exists(fpath) and os.access(fpath, os.X_OK):
+            return True
+    return False
+
 
 def check_database(args):
-	if args['db'] is None and 'MAGPURIFYDB' in os.environ:
-		args['db'] = os.environ['MAGPURIFYDB']
-	if args['db'] is None:
-		error = "\nError: No reference database specified\n"
-		error += "Use the flag --db to specify a database,\n"
-		error += "Or set the MAGPURIFYDB environmental variable: export MAGPURIFYDB=/path/to/MAGpurify_db_v1.0.0\n"
-		sys.exit(error)
-	if not os.path.isdir(args['db']):
-		error = "\nError: Specified reference database does not exist: %s\n" % args['db']
-		error += "\nCheck that you've entered the path correctly and the database exists\n"
-		sys.exit(error)
+    if args['db'] is None and 'MAGPURIFYDB' in os.environ:
+        args['db'] = os.environ['MAGPURIFYDB']
+    if args['db'] is None:
+        error = "\nError: No reference database specified\n"
+        error += "Use the flag -d to specify a database,\n"
+        error += "Or set the MAGPURIFYDB environmental variable: export MAGPURIFYDB=/path/to/MAGpurify_db_v1.0.0\n"
+        sys.exit(error)
+    if not os.path.isdir(args['db']):
+        error = "\nError: Specified reference database does not exist: %s\n" % args['db']
+        error += (
+            "\nCheck that you've entered the path correctly and the database exists\n"
+        )
+        sys.exit(error)
+
 
 def run_process(command):
-	""" Capture stdout, stderr. Check unix exit code and exit if non-zero """
-	import subprocess as sp
-	process = sp.Popen(command, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
-	out, err = process.communicate()
-	if process.returncode != 0:
-		err_message = "\nError encountered executing:\n%s\n\nError message:\n%s\n" % (command, err)
-		sys.exit(err_message)
-	return out, err
+    """ Capture stdout, stderr. Check unix exit code and exit if non-zero """
+    import subprocess as sp
 
-def parse_fasta(fpath):
-	return Bio.SeqIO.parse(fpath, "fasta")
+    process = sp.Popen(command, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
+    out, err = process.communicate()
+    if process.returncode != 0:
+        err_message = "\nError encountered executing:\n%s\n\nError message:\n%s\n" % (
+            command,
+            err,
+        )
+        sys.exit(err_message)
+    return out, err
+
 
 def parse_last(inpath):
-	fields = ['qid', 'tid', 'pid', 'aln', 'mis', 'gap', 'qstart', 'qend',
-			  'tstart', 'tend', 'eval', 'score', 'qlen', 'tlen']
-	for line in open(inpath):
-		if line[0] == '#':
-			continue
-		else:
-			values = line.rstrip().split()
-			d = dict([(f,v) for f,v in zip(fields, values)])
-			d['qcov'] = float(d['aln'])/float(d['qlen'])
-			d['tcov'] = float(d['aln'])/float(d['tlen'])
-			yield d
-			
+    fields = [
+        'qid',
+        'tid',
+        'pid',
+        'aln',
+        'mis',
+        'gap',
+        'qstart',
+        'qend',
+        'tstart',
+        'tend',
+        'eval',
+        'score',
+        'qlen',
+        'tlen',
+    ]
+    for line in open(inpath):
+        if line[0] == '#':
+            continue
+        else:
+            values = line.rstrip().split()
+            d = dict([(f, v) for f, v in zip(fields, values)])
+            d['qcov'] = float(d['aln']) / float(d['qlen'])
+            d['tcov'] = float(d['aln']) / float(d['tlen'])
+            yield d
+
+
 def parse_blast(input, type='file'):
-	formats = [('qname', str),
-			   ('tname', str),
-			   ('pid', float),
-			   ('aln', int),
-			   ('mis', int),
-			   ('gap', int),
-			   ('qstart', int),
-			   ('qend', int),
-			   ('tstart', int),
-			   ('tend', int),
-			   ('evalue', float),
-			   ('bitscore', float),
-		  	   ('qlen', int),
-			   ('tlen', int)]
-	if type=='file':
-		lines = open(input).read().rstrip('\n').split('\n')
-	else:
-		lines = input.rstrip('\n').split('\n')
-	if lines == ['']:
-		return
-	for line in lines:
-		values = line.split('\t')
-		record = dict([(f[0], f[1](v)) for f,v in zip(formats, values)])
-		record['qcov'] = 100*record['aln']/float(record['qlen'])
-		record['tcov'] = 100*record['aln']/float(record['tlen'])
-		yield record
+    formats = [
+        ('qname', str),
+        ('tname', str),
+        ('pid', float),
+        ('aln', int),
+        ('mis', int),
+        ('gap', int),
+        ('qstart', int),
+        ('qend', int),
+        ('tstart', int),
+        ('tend', int),
+        ('evalue', float),
+        ('bitscore', float),
+        ('qlen', int),
+        ('tlen', int),
+    ]
+    if type == 'file':
+        lines = open(input).read().rstrip('\n').split('\n')
+    else:
+        lines = input.rstrip('\n').split('\n')
+    if lines == ['']:
+        return
+    for line in lines:
+        values = line.split('\t')
+        record = dict([(f[0], f[1](v)) for f, v in zip(formats, values)])
+        record['qcov'] = 100 * record['aln'] / float(record['qlen'])
+        record['tcov'] = 100 * record['aln'] / float(record['tlen'])
+        yield record
+
 
 def parse_mash(fpath):
-	fields = ['query', 'target', 'dist', 'pvalue', 'fraction']
-	formats = [str, str, float, float, str]
-	out = open(fpath).read()
-	if len(out) > 0:
-		lines = out.rstrip('\n').split('\n')
-		for line in lines:
-			values = line.split()
-			rec = dict([(f,m(v)) for f,m,v in zip(fields, formats, values)])
-			yield rec
+    fields = ['query', 'target', 'dist', 'pvalue', 'fraction']
+    formats = [str, str, float, float, str]
+    out = open(fpath).read()
+    if len(out) > 0:
+        lines = out.rstrip('\n').split('\n')
+        for line in lines:
+            values = line.split()
+            rec = dict([(f, m(v)) for f, m, v in zip(fields, formats, values)])
+            yield rec
+
 
 def parse_hmmsearch(fpath):
-	with open(fpath) as infile:
-		fields = ['tname','tacc','tlen','qname','qacc','qlen','evalue','score',
-				  'bias','ndom','tdom','c-evalue','i-evalue','domscore','dombias',
-				  'hmmfrom','hmmto','alifrom','alito','envfrom','envto','prob','tdesc']
-		formts = [str,str,int,str,str,int,float,float,float,int,int,float,
-				  float,float,float,int,int,int,int,int,int,float,str]
-		for line in infile:
-			if line[0] == '#':
-				continue
-			values = line.rstrip('\n').split(None, 22)
-			r = dict([(field, format(value)) for field, format, value in zip(fields, formts, values)])
-			r['tcov'] = float(r['alito'] - r['alifrom'] + 1)/r['tlen'] # target is gene
-			r['qcov'] = float(r['hmmto'] - r['hmmfrom'] + 1)/r['qlen'] # query is hmm
-			yield r
+    with open(fpath) as infile:
+        fields = [
+            'tname',
+            'tacc',
+            'tlen',
+            'qname',
+            'qacc',
+            'qlen',
+            'evalue',
+            'score',
+            'bias',
+            'ndom',
+            'tdom',
+            'c-evalue',
+            'i-evalue',
+            'domscore',
+            'dombias',
+            'hmmfrom',
+            'hmmto',
+            'alifrom',
+            'alito',
+            'envfrom',
+            'envto',
+            'prob',
+            'tdesc',
+        ]
+        formts = [
+            str,
+            str,
+            int,
+            str,
+            str,
+            int,
+            float,
+            float,
+            float,
+            int,
+            int,
+            float,
+            float,
+            float,
+            float,
+            int,
+            int,
+            int,
+            int,
+            int,
+            int,
+            float,
+            str,
+        ]
+        for line in infile:
+            if line[0] == '#':
+                continue
+            values = line.rstrip('\n').split(None, 22)
+            r = dict(
+                [
+                    (field, format(value))
+                    for field, format, value in zip(fields, formts, values)
+                ]
+            )
+            r['tcov'] = float(r['alito'] - r['alifrom'] + 1) / r['tlen']  # target is gene
+            r['qcov'] = float(r['hmmto'] - r['hmmfrom'] + 1) / r['qlen']  # query is hmm
+            yield r
+
 
 def fetch_hmm_best_hits(fpath):
-	gene_to_aln = {}
-	for aln in parse_hmmsearch(fpath):
-		if aln['tname'] not in gene_to_aln:
-			gene_to_aln[aln['tname']] = aln
-		elif aln['score'] > gene_to_aln[aln['tname']]['score']:
-			gene_to_aln[aln['tname']] = aln
-	return gene_to_aln
+    gene_to_aln = {}
+    for aln in parse_hmmsearch(fpath):
+        if aln['tname'] not in gene_to_aln:
+            gene_to_aln[aln['tname']] = aln
+        elif aln['score'] > gene_to_aln[aln['tname']]['score']:
+            gene_to_aln[aln['tname']] = aln
+    return gene_to_aln
+
 
 def run_prodigal(fna_path, out_dir):
-	cmd = "prodigal "
-	cmd += "-i %s " % fna_path # input fna
-	cmd += "-a %s/genes.faa " % out_dir # protein seqs
-	cmd += "-d %s/genes.ffn " % out_dir # nucleotide seqs
-	cmd += "-o %s/genes.out " % out_dir # prodigal output
-	cmd += "> /dev/null" # prodigal output
-	out, err = run_process(cmd)
+    cmd = "prodigal "
+    cmd += "-i %s " % fna_path  # input fna
+    cmd += "-a %s/genes.faa " % out_dir  # protein seqs
+    cmd += "-d %s/genes.ffn " % out_dir  # nucleotide seqs
+    cmd += "-o %s/genes.out " % out_dir  # prodigal output
+    cmd += "> /dev/null"  # prodigal output
+    out, err = run_process(cmd)
+
 
 def run_lastal(db_dir, out_dir, threads=1, seed_freq=10):
-	cmd = "lastal -p BLOSUM62 -P 1 -f blasttab+ "
-	cmd += "-m %s " % seed_freq
-	cmd += "%s/clade-markers/markers.faa " % db_dir
-	cmd += "%s/genes.faa " % out_dir
-	cmd += "-P %s " % threads
-	cmd += "> %s/genes.m8 " % out_dir
-	out, err = run_process(cmd)
+    cmd = "lastal -p BLOSUM62 -P 1 -f blasttab+ "
+    cmd += "-m %s " % seed_freq
+    cmd += "%s/clade-markers/markers.faa " % db_dir
+    cmd += "%s/genes.faa " % out_dir
+    cmd += "-P %s " % threads
+    cmd += "> %s/genes.m8 " % out_dir
+    out, err = run_process(cmd)
+
 
 def run_hmmsearch(db_dir, in_path, out_dir, threads=1):
-	cmd = "hmmsearch "
-	cmd += "--noali "
-	cmd += "--domtblout %s/phyeco.hmmsearch " % out_dir
-	cmd += "--cpu %s " % threads
-	cmd += "--cut_ga "
-	cmd += "%s/phylo-markers/PhyEco.hmm " % db_dir
-	cmd += "%s/genes.faa " % in_path
-	out, err = run_process(cmd)
+    cmd = "hmmsearch "
+    cmd += "--noali "
+    cmd += "--domtblout %s/phyeco.hmmsearch " % out_dir
+    cmd += "--cpu %s " % threads
+    cmd += "--cut_ga "
+    cmd += "%s/phylo-markers/PhyEco.hmm " % db_dir
+    cmd += "%s/genes.faa " % in_path
+    out, err = run_process(cmd)
+
 
 def run_blastp(db_path, query_path, out_path, threads=1, max_targets=1, qcov=40):
-	cmd = "blastp "
-	cmd += "-db %s " % db_path
-	cmd += "-query %s " % query_path
-	cmd += "-out %s " % out_path
-	cmd += "-outfmt '6 std qlen slen' "
-	cmd += "-num_threads %s " % threads
-	cmd += "-max_target_seqs %s " % max_targets
-	cmd += "-qcov_hsp_perc %s " % qcov
-	cmd += "-max_hsps 1 "
-	out, err = run_process(cmd)
+    cmd = "blastp "
+    cmd += "-db %s " % db_path
+    cmd += "-query %s " % query_path
+    cmd += "-out %s " % out_path
+    cmd += "-outfmt '6 std qlen slen' "
+    cmd += "-num_threads %s " % threads
+    cmd += "-max_target_seqs %s " % max_targets
+    cmd += "-qcov_hsp_perc %s " % qcov
+    cmd += "-max_hsps 1 "
+    out, err = run_process(cmd)
+
 
 def run_blastn(db_path, query_path, out_path, threads=1, max_targets=1, qcov=40):
-	cmd = "blastn -task blastn "
-	cmd += "-db %s " % db_path
-	cmd += "-query %s " % query_path
-	cmd += "-out %s " % out_path
-	cmd += "-outfmt '6 std qlen slen' "
-	cmd += "-num_threads %s " % threads
-	cmd += "-max_target_seqs %s " % max_targets
-	cmd += "-qcov_hsp_perc %s " % qcov
-	cmd += "-max_hsps 1 "
-	out, err = run_process(cmd)
+    cmd = "blastn -task blastn "
+    cmd += "-db %s " % db_path
+    cmd += "-query %s " % query_path
+    cmd += "-out %s " % out_path
+    cmd += "-outfmt '6 std qlen slen' "
+    cmd += "-num_threads %s " % threads
+    cmd += "-max_target_seqs %s " % max_targets
+    cmd += "-qcov_hsp_perc %s " % qcov
+    cmd += "-max_hsps 1 "
+    out, err = run_process(cmd)
+
 
 def parse_fasta(path):
-	with open(path) as file:
-		try: id = next(file).split()[0].lstrip('>')
-		except: return
-		seq = ''
-		for line in file:
-			if line[0]=='>':
-				yield id, seq
-				try: id = line.split()[0].lstrip('>')
-				except: return
-				seq = ''
-			else:
-				seq += line.rstrip()
-		yield id, seq
-
+    with open(path) as file:
+        for record in SeqIO.parse(file, 'fasta'):
+            id = record.id
+            seq = str(record.seq).upper()
+            yield id, seq
 

--- a/run_qc.py
+++ b/run_qc.py
@@ -3,61 +3,75 @@
 import sys
 import argparse
 
+
 def get_program():
-	if len(sys.argv) == 1 or sys.argv[1] in ['-h', '--help']:
-		print('MAGpurify: Identify and remove incorrectly binned contigs from metagenome-assembled genomes')
-		print('')
-		print('Usage: run_qc.py <command> [options]')
-		print('')
-		print('Commands:')
-		print('    phylo-markers: find taxonomic discordant contigs using db of phylogenetic marker genes')
-		print('    clade-markers: find taxonomic discordant contigs using db of clade-specific marker genes')
-		print('      conspecific: find contigs that fail to align to closely related genomes')
-		print('       tetra-freq: find contigs with outlier tetranucleotide frequency')
-		print('       gc-content: find contigs with outlier gc content')
-		print('     known-contam: find contigs that match a database of known contaminants')
-		print('        clean-bin: remove identified contigs from bin')
-		print('')
-		print('Note: use run_qc.py <command> -h to view usage for a specific command')
-		quit()
-	elif sys.argv[1] not in ['phylo-markers', 'clade-markers', 'conspecific',
-	                         'tetra-freq', 'gc-content', 'known-contam', 'clean-bin']:
-		sys.exit("\nError: Unrecognized command: '%s'\n" % sys.argv[1])
-		quit()
-	else:
-		return sys.argv[1]
+    if len(sys.argv) == 1 or sys.argv[1] in ['-h', '--help']:
+        print('MAGpurify: Identify and remove incorrectly binned contigs from metagenome-assembled genomes')
+        print('')
+        print('Usage: run_qc.py <command> [options]')
+        print('')
+        print('Commands:')
+        print('    phylo-markers: find taxonomic discordant contigs using db of phylogenetic marker genes')
+        print('    clade-markers: find taxonomic discordant contigs using db of clade-specific marker genes')
+        print('      conspecific: find contigs that fail to align to closely related genomes')
+        print('       tetra-freq: find contigs with outlier tetranucleotide frequency')
+        print('       gc-content: find contigs with outlier gc content')
+        print('     known-contam: find contigs that match a database of known contaminants')
+        print('        clean-bin: remove identified contigs from bin')
+        print('')
+        print('Note: use run_qc.py <command> -h to view usage for a specific command')
+        quit()
+    elif sys.argv[1] not in [
+        'phylo-markers',
+        'clade-markers',
+        'conspecific',
+        'tetra-freq',
+        'gc-content',
+        'known-contam',
+        'clean-bin',
+    ]:
+        sys.exit("\nError: Unrecognized command: '%s'\n" % sys.argv[1])
+        quit()
+    else:
+        return sys.argv[1]
+
 
 if __name__ == "__main__":
-	
-	program = get_program()
-	
-	if program == 'phylo-markers':
-		from magpurify import uscmg
-		uscmg.main()
 
-	if program == 'clade-markers':
-		from magpurify import csmg
-		csmg.main()
+    program = get_program()
 
-	if program == 'conspecific':
-		from magpurify import conspecific
-		conspecific.main()
+    if program == 'phylo-markers':
+        from magpurify import uscmg
 
-	if program == 'tetra-freq':
-		from magpurify import tetra
-		tetra.main()
+        uscmg.main()
 
-	if program == 'gc-content':
-		from magpurify import gc
-		gc.main()
+    if program == 'clade-markers':
+        from magpurify import csmg
 
-	if program == 'known-contam':
-		from magpurify import contam
-		contam.main()
+        csmg.main()
 
-	if program == 'clean-bin':
-		from magpurify import clean
-		clean.main()
+    if program == 'conspecific':
+        from magpurify import conspecific
 
+        conspecific.main()
 
+    if program == 'tetra-freq':
+        from magpurify import tetra
+
+        tetra.main()
+
+    if program == 'gc-content':
+        from magpurify import gc
+
+        gc.main()
+
+    if program == 'known-contam':
+        from magpurify import contam
+
+        contam.main()
+
+    if program == 'clean-bin':
+        from magpurify import clean
+
+        clean.main()
 


### PR DESCRIPTION
Hi Stephen!

This PR does the following modifications:
- Code was ported from Python 2 to Python 3 as Python 2 was officially retired in January 2020.
- The error message `Use the flag --db to specify a database` was altered to `Use the flag -d to specify a database` to match the correct argument name.
- The FASTA files are now read with Biopython, making parser much faster.
- GC content is now computed with Biopython.
- The requirement of specifying a database with `-d` was removed for `gc-content` and `tetra-freq`, since those modules don't use the database.
- The code was formated with Black to keep formatting consistent.

This PR also fixes https://github.com/snayfach/MAGpurify/issues/7 and https://github.com/snayfach/MAGpurify/issues/6.