### PR TITLE
Add coverage module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAGpurify
 
-<b> This is not a production-ready software repository and is still under active development. Bugs and feature requests will not addressed. Please use with caution. If this code is useful, please cite: http://dx.doi.org/10.1038/s41586-019-1058-x</b>
+**This is not a production-ready software repository and is still under active development. Bugs and feature requests will not addressed. Please use with caution. If this code is useful, please cite: http://dx.doi.org/10.1038/s41586-019-1058-x**
 
 This package uses a combination of different features and algorithms to identify contamination in metagenome-assembled genomes (MAGs). Contamination is defined as contigs that originated from a different species relative to the dominant organism present in the MAG.
 
@@ -21,6 +21,7 @@ Install 3rd party programs:
 * [HMMER (v3.1b2)](http://hmmer.org/download.html)
 * [LAST (v828)](http://last.cbrc.jp)
 * [Mash (v2.0)](https://github.com/marbl/Mash/releases)
+* [CoverM (v0.3.2)](https://github.com/wwood/CoverM/releases)
 * Make sure these programs are located on your PATH
 * Tested versions indicated, but other versions might also work
 
@@ -29,59 +30,79 @@ Download the reference database: [MAGpurify-db-v1.0.tar.bz2](http://bit.ly/MAGpu
 And unpack the database:
 `tar -jxvf MAGpurify-db-v1.0.tar.bz2`
 
- Update your environment:
+Update your environment:
 `export PATH=$PATH:/path/to/MAGpurify`
 `export MAGPURIFYDB=/path/to/MAGpurify-db-v1.0`
 
 
 ## A quick overview
 
-The program is broken down into several modules, which can be viewed using: `run_qc.py -h`
+The program is broken down into several modules:
 
 ```
+$ run_qc.py -h
+
 MAGpurify: Identify and remove incorrectly binned contigs from metagenome-assembled genomes
 
 Usage: run_qc.py <command> [options]
 
 Commands:
-    phylo-markers find taxonomic discordant contigs using db of phylogenetic marker genes
-    clade-markers find taxonomic discordant contigs using db of clade-specific marker genes
-      conspecific find contigs that fail to align to closely related genomes
-       tetra-freq find contigs with outlier tetranucleotide frequency
-       gc-content find contigs with outlier gc content
-     known-contam find contigs that match a database of known contaminants
-        clean-bin remove identified contigs from bin
+    phylo-markers: find taxonomic discordant contigs using db of phylogenetic marker genes
+    clade-markers: find taxonomic discordant contigs using db of clade-specific marker genes
+      conspecific: find contigs that fail to align to closely related genomes
+       tetra-freq: find contigs with outlier tetranucleotide frequency
+       gc-content: find contigs with outlier gc content
+         coverage: find contigs with outlier coverage profile
+     known-contam: find contigs that match a database of known contaminants
+        clean-bin: remove identified contigs from bin
 
 Note: use run_qc.py <command> -h to view usage for a specific command
 ```
 
-First, identify incorrectly binned contigs using: `run_qc.py <command> <input genome> <output directory>`
-And then remove these contigs using: `run_qc.py clean-bin <input genome> <output directory>`
+MAGpurify modules are executed sequentially using the following command structure:
+
+```
+$ run_qc.py <module> <input mag> <output directory>
+```
+
+After the desired modules have been executed, the flagged contigs are removed:
+
+```
+$ run_qc.py clean-bin <input mag> <output directory>
+```
+
 It's as simple as that!
 
-All of the modules can be run using the standard MAGpurify database, with the exception of the `conspecific` module which requires that you build your own database (see below)
+## Dependency on external data
+
+`tetra-freq` and `gc-content` don't rely on external data. The `phylo-markers`, `clade-markers` and `known-contam` modules can be run using the standard MAGpurify database. The `conspecific` module requires that you build your own database. The `coverage` module requires input BAM files.
 
 ## An example using the default database
 
 The next few lines will show you how to run the software using a single MAG included with the software.
 
 First, run the individual modules to predict contamination in the example `example/test.fna` file and store the results in `example/output`:
-`run_qc.py phylo-markers example/test.fna example/output`
-`run_qc.py clade-markers example/test.fna example/output`
-`run_qc.py tetra-freq example/test.fna example/output`
-`run_qc.py gc-content example/test.fna example/output`
-`run_qc.py known-contam example/test.fna example/output`
-
-The output of each module is stored in the output directory:
-`ls example/output`
-`> clade-markers gc-content  known-contam  phylo-markers  tetra-freq`
-
-Now remove the contamintion from the bin:
-`run_qc.py clean-bin example/test.fna example/output`
-
-You should see the following output:
 
 ```
+$ run_qc.py phylo-markers example/test.fna example/output
+$ run_qc.py clade-markers example/test.fna example/output
+$ run_qc.py tetra-freq example/test.fna example/output
+$ run_qc.py gc-content example/test.fna example/output
+$ run_qc.py known-contam example/test.fna example/output
+```
+
+The output of each module is stored in the output directory:
+```
+$ ls example/output
+
+clade-markers gc-content known-contam phylo-markers tetra-freq
+```
+
+Now remove the contamintion from the bin with `clean-bin`:
+
+```
+$ run_qc.py clean-bin example/test.fna example/output
+
 ## Reading genome bin
    genome length: 704 contigs, 4144.3 Kbp
 
@@ -89,69 +110,86 @@ You should see the following output:
    phylo-markers: 1 contigs, 17.18 Kbp
    clade-markers: 3 contigs, 17.1 Kbp
    conspecific: no output file found
-   tetra-freq: 1 contigs, 4.8 Kbp
+   tetra-freq: 0 contigs, 0.0 Kbp
    gc-content: 0 contigs, 0.0 Kbp
+   coverage: no output file found
    known-contam: 0 contigs, 0.0 Kbp
 
 ## Removing flagged contigs
-   removed: 5 contigs, 39.08 Kbp
-   remains: 699 contigs, 4105.22 Kbp
-   cleaned bin: output/cleaned_bin.fna
+   removed: 4 contigs, 34.28 Kbp
+   remains: 700 contigs, 4110.03 Kbp
+   cleaned bin: example/output/cleaned_bin.fna
 ```
 
-In summary, 3 of the 6 modules predicted at least one contaminant and the cleaned bin was written to `example/output/cleaned_bin.fna`
+In summary, 2 of the 7 modules predicted at least one contaminant and the cleaned bin was written to `example/output/cleaned_bin.fna`
 
-## An example using the conspecific module
+## An example using the `conspecific` module
 
-To run the conspecific module, you need to build your own reference database using Mash. We have provided some dummy files to illustrate this:
-`mash sketch -l example/ref_genomes.list -o example/ref_genomes`
+To run the `conspecific` module, you need to build your own reference database using Mash. We've provided some dummy files to illustrate this (but you shouldn't use them with your data!):
 
-Which will create a Mash sketch of the genomes listed in `example/ref_genomes.list` that are located in `example/ref_genomes`. The sketch will be written to `example/ref_genomes.msh`
+```
+$ mash sketch -l example/ref_genomes.list -o example/ref_genomes
+```
+
+This command will create a Mash sketch of the genomes listed in `example/ref_genomes.list` that are located in `example/ref_genomes`. The sketch will be written to `example/ref_genomes.msh`
 
 Now you can run the conspecific module:
-`run_qc.py conspecific example/test.fna example/output --mash-sketch example/ref_genomes.msh`
-
-Which should produce the output:
 
 ```
+$ run_qc.py conspecific example/test.fna example/output --mash-sketch example/ref_genomes.msh
+
 ## Finding conspecific genomes in database
    25 genomes within 0.05 mash-dist
-   list of genomes: example/test_out/conspecific/conspecific.list
-   mash output: example/test_out/conspecific/mash.dist
+   list of genomes: example/output/conspecific/conspecific.list
+   mash output: example/output/conspecific/mash.dist
 
 ## Performing pairwise alignment of contigs in bin to database genomes
    total alignments: 12125
 
 ## Summarizing alignments
-   contig features: example/test_out/conspecific/contig_hits.tsv
+   contig features: example/output/conspecific/contig_hits.tsv
 
 ## Identifying contigs with no conspecific alignments
    238 flagged contigs, 450.02 Kbp
-   flagged contigs: example/test_out/conspecific/flagged_contigs
+   flagged contigs: example/output/conspecific/flagged_contigs
 ```
 
-So, the conspecific module alone identified 238 putative contaminants! This illustrates that this module can be very sensitive when your MAG is similar to closely related genomes in your reference database...or to other MAGs!
+So, the conspecific module alone identified 238 putative contaminants! This illustrates that this module can be very sensitive when your MAG is similar to closely related genomes in your reference database… or to other MAGs!
 
+## An example using the `coverage` module
+
+To run the `coverage` module, you need to input a sorted BAM file containing reads mapped to the MAG (or the original metagenome, as long as the contig name is unchanged). You can also input multiple BAM files and MAGpurify will pick the one with the greatest average contig coverage.
+
+```
+$ run_qc.py conspecific example/test.fna example/output --bams ./BAM/sample_1.bam ./BAM/sample_2.bam ./BAM/sample_3.bam
+
+## Computing contig coverage
+
+## Identifying outlier contigs
+
+## Sample being used for outlier detection: sample_2
+   2 flagged contigs: example/output/coverage/flagged_contigs
+```
 
 ## Details on the individual modules
 
-<b>phylo-markers</b>
+### phylo-markers
 This module works by taxonomically annotating your contigs based on a database of phylogenetic marker genes from the PhyEco database and identifying taxonomically discordant contigs.
 
-<b>clade-markers</b>
+### clade-markers
 This module works in a very similar way to `phylo-markers`, but instead uses clade-specific markers from the MetaPhlAn 2 database for taxonomic annotation.
 
-<b>conspecific</b>
+### conspecific
 The logic behind this module is that strains of the same species should have similarity along most of the genome. Therefore, this module works by first finding strains of the same species, and then performing pairwise alignment of contigs. Contaminants are identified which do not align at all between genomes.
 
-<b>tetra-freq</b>
+### tetra-freq
 This module works by identifying contigs with outlier nucleotide composition based on tetranucleotide frequencies (TNF). In order to reduce TNF down to a single dimension, principal component analysis (PCA) is performed and the first principal component is used.
 
-<b>gc-content</b>
+### gc-content
 This module works by identifying contigs with outlier nucleotide composition based on GC content.
 
-<b>known-contam</b>
-This module works by identifying contigs that match a database of known contaminants. So far, the human genome and phiX genome are the only ones in the database.
+### coverage
+This module works by identifying contigs with outlier coverage based on read mapping information.
 
-<b>read-depth</b>
-<i>coming soon...</i>
+### known-contam
+This module works by identifying contigs that match a database of known contaminants. So far, the human genome and phiX genome are the only ones in the database.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ clade-markers gc-content known-contam phylo-markers tetra-freq
 Now remove the contamintion from the bin with `clean-bin`:
 
 ```
-$ run_qc.py clean-bin example/test.fna example/output
+$ run_qc.py clean-bin example/test.fna example/output --output-fasta example/test_cleaned.fna
 
 ## Reading genome bin
    genome length: 704 contigs, 4144.3 Kbp
@@ -118,7 +118,7 @@ $ run_qc.py clean-bin example/test.fna example/output
 ## Removing flagged contigs
    removed: 4 contigs, 34.28 Kbp
    remains: 700 contigs, 4110.03 Kbp
-   cleaned bin: example/output/cleaned_bin.fna
+   cleaned bin: example/test_cleaned.fna
 ```
 
 In summary, 2 of the 7 modules predicted at least one contaminant and the cleaned bin was written to `example/output/cleaned_bin.fna`

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ run_qc.py <module> <input mag> <output directory>
 After the desired modules have been executed, the flagged contigs are removed:
 
 ```
-$ run_qc.py clean-bin <input mag> <output directory>
+$ run_qc.py clean-bin <input mag> <output directory> --output-fasta <output mag>
 ```
 
 It's as simple as that!

--- a/magpurify/clean.py
+++ b/magpurify/clean.py
@@ -32,7 +32,7 @@ def main():
     for id, seq in utility.parse_fasta(args['fna']):
         bin[id] = seq
     bin_length = round(sum(len(_) for _ in bin.values()) / 1000, 2)
-    print("   genome length: %s contigs, %s Kbp" % (len(bin), bin_length))
+    print(f"   genome length: {len(bin)} contigs, {bin_length} Kbp")
 
     print("\n## Reading flagged contigs")
     flagged_contigs = []
@@ -46,14 +46,14 @@ def main():
         'known-contam',
     ]
     for program in programs:
-        path = '%s/%s/flagged_contigs' % (args['out'], program)
+        path = f"{args['out']}/{program}/flagged_contigs"
         if not os.path.exists(path):
-            print("   %s: no output file found" % program)
+            print(f"   {program}: no output file found")
         else:
             contigs = [_.rstrip() for _ in open(path)]
             bases = round(sum(len(bin[id]) for id in contigs) / 1000, 2)
             flagged_contigs += contigs
-            print("   %s: %s contigs, %s Kbp" % (program, len(contigs), bases))
+            print(f"   {program}: {len(contigs)} contigs, {bases} Kbp")
     flagged_contigs = list(set(flagged_contigs))
     flagged_length = round(sum(len(bin[id]) for id in flagged_contigs) / 1000, 2)
     print("\n## Removing flagged contigs")
@@ -61,10 +61,10 @@ def main():
     for id in flagged_contigs:
         del clean[id]
     clean_length = round(sum(len(_) for _ in clean.values()) / 1000, 2)
-    print("   removed: %s contigs, %s Kbp" % (len(flagged_contigs), flagged_length))
-    print("   remains: %s contigs, %s Kbp" % (len(clean), clean_length))
-    out = '%s/cleaned_bin.fna' % args['out']
+    print(f"   removed: {len(flagged_contigs)} contigs, {flagged_length} Kbp")
+    print(f"   remains: {len(clean)} contigs, {clean_length} Kbp")
+    out = f"{args['out']}/cleaned_bin.fna"
     with open(out, 'w') as f:
         for id, seq in clean.items():
             f.write('>' + id + '\n' + seq + '\n')
-    print("   cleaned bin: %s" % out)
+    print(f"   cleaned bin: {out}")

--- a/magpurify/clean.py
+++ b/magpurify/clean.py
@@ -13,10 +13,10 @@ def fetch_args():
         usage=argparse.SUPPRESS,
         description="MAGpurify: clean module: remove flagged contigs from input genome",
     )
-    parser.add_argument('program', help=argparse.SUPPRESS)
-    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument("program", help=argparse.SUPPRESS)
+    parser.add_argument("fna", type=str, help="""Path to input genome in FASTA format""")
     parser.add_argument(
-        'out',
+        "out",
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
@@ -29,7 +29,7 @@ def main():
     utility.check_input(args)
     print("\n## Reading genome bin")
     bin = {}
-    for id, seq in utility.parse_fasta(args['fna']):
+    for id, seq in utility.parse_fasta(args["fna"]):
         bin[id] = seq
     bin_length = round(sum(len(_) for _ in bin.values()) / 1000, 2)
     print(f"   genome length: {len(bin)} contigs, {bin_length} Kbp")
@@ -37,13 +37,13 @@ def main():
     print("\n## Reading flagged contigs")
     flagged_contigs = []
     programs = [
-        'phylo-markers',
-        'clade-markers',
-        'conspecific',
-        'tetra-freq',
-        'gc-content',
-        'coverage',
-        'known-contam',
+        "phylo-markers",
+        "clade-markers",
+        "conspecific",
+        "tetra-freq",
+        "gc-content",
+        "coverage",
+        "known-contam",
     ]
     for program in programs:
         path = f"{args['out']}/{program}/flagged_contigs"
@@ -64,7 +64,7 @@ def main():
     print(f"   removed: {len(flagged_contigs)} contigs, {flagged_length} Kbp")
     print(f"   remains: {len(clean)} contigs, {clean_length} Kbp")
     out = f"{args['out']}/cleaned_bin.fna"
-    with open(out, 'w') as f:
+    with open(out, "w") as f:
         for id, seq in clean.items():
-            f.write('>' + id + '\n' + seq + '\n')
+            f.write(">" + id + "\n" + seq + "\n")
     print(f"   cleaned bin: {out}")

--- a/magpurify/clean.py
+++ b/magpurify/clean.py
@@ -9,7 +9,7 @@ from . import utility
 
 def fetch_args():
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage=argparse.SUPPRESS,
         description="MAGpurify: clean module: remove flagged contigs from input genome",
     )
@@ -42,6 +42,7 @@ def main():
         'conspecific',
         'tetra-freq',
         'gc-content',
+        'coverage',
         'known-contam',
     ]
     for program in programs:
@@ -67,74 +68,3 @@ def main():
         for id, seq in clean.items():
             f.write('>' + id + '\n' + seq + '\n')
     print("   cleaned bin: %s" % out)
-
-
-#    check_input(args)
-#    check_database(args)
-#
-#    contigs = {}
-#    for rec in parse_fasta(args['fna_path']):
-#        contig = Contig()
-#        contig.id = rec.id
-#        contig.seq = str(rec.seq)
-#        contig.length = len(rec.seq)
-#        contig.flags = []
-#        contigs[rec.id] = contig
-#
-#    if args['modules'] and 'uscmg' in args['modules']:
-#        from magpurify import uscmg
-#        check_dependencies(['prodigal', 'blastp', 'hmmsearch'])
-#        sys.stdout.write("discordant taxonomy based on universal-single-copy marker-genes\n")
-#        flagged = magpurify.uscmg.main(args)
-#        for id in flagged:
-#            contigs[id].flags.append('uscmg')
-#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
-#
-#    if args['modules'] and 'csmg' in args['modules']:
-#        from magpurify import csmg
-#        check_dependencies(['prodigal', 'lastal'])
-#        sys.stdout.write("discordant taxonomy based on clade-specific marker-genes\n")
-#        flagged = csmg.main(args)
-#        for id in flagged:
-#            contigs[id].flags.append('csmg')
-#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
-#
-#    if args['modules'] and 'contdb' in args['modules']:
-#        from magpurify import contam
-#        check_dependencies(['blastn'])
-#        sys.stdout.write("hits to database of contaminants\n")
-#        flagged = contam.main(args)
-#        for id in flagged:
-#            contigs[id].flags.append('contdb')
-#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
-#
-#    if args['modules'] and 'tnf' in args['modules']:
-#        check_dependencies([])
-#        sys.stdout.write("outlier tetranucleotide frequency\n")
-#        from magpurify import tetra
-#        flagged = tetra.main(args)
-#        for id in flagged:
-#            contigs[id].flags.append('tnf')
-#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
-#
-#    if args['modules'] and 'gc' in args['modules']:
-#        check_dependencies([])
-#        sys.stdout.write("outlier gc content\n")
-#        from magpurify import gc
-#        flagged = gc.main(args)
-#        for id in flagged:
-#            contigs[id].flags.append('gcc')
-#        sys.stdout.write("   %s contigs flagged\n" % len(flagged))
-#
-#    with open('%s/cleaned.fa' % args['out_dir'], 'w') as f:
-#        for contig in contigs.values():
-#            if len(contig.flags) > 0:
-#                continue
-#            f.write('>'+contig.id+'\n'+contig.seq+'\n')
-#
-#    with open('%s/summary.tsv' % args['out_dir'], 'w') as f:
-#        fields = ['contig_id', 'length', 'flags']
-#        f.write('\t'.join(fields)+'\n')
-#        for contig in contigs.values():
-#            values = [contig.id, str(contig.length), ','.join(contig.flags)]
-#            f.write('\t'.join(values)+'\n')

--- a/magpurify/clean.py
+++ b/magpurify/clean.py
@@ -20,6 +20,12 @@ def fetch_args():
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
+    parser.add_argument(
+        "--output-fasta",
+        type=str,
+        required=True,
+        help="""Path to the output FASTA file""",
+    )
     args = vars(parser.parse_args())
     return args
 
@@ -33,7 +39,6 @@ def main():
         bin[id] = seq
     bin_length = round(sum(len(_) for _ in bin.values()) / 1000, 2)
     print(f"   genome length: {len(bin)} contigs, {bin_length} Kbp")
-
     print("\n## Reading flagged contigs")
     flagged_contigs = []
     programs = [
@@ -63,8 +68,7 @@ def main():
     clean_length = round(sum(len(_) for _ in clean.values()) / 1000, 2)
     print(f"   removed: {len(flagged_contigs)} contigs, {flagged_length} Kbp")
     print(f"   remains: {len(clean)} contigs, {clean_length} Kbp")
-    out = f"{args['out']}/cleaned_bin.fna"
-    with open(out, "w") as f:
+    with open(args['output_fasta'], "w") as f:
         for id, seq in clean.items():
             f.write(">" + id + "\n" + seq + "\n")
-    print(f"   cleaned bin: {out}")
+    print(f"   cleaned bin: {args['output_fasta']}")

--- a/magpurify/conspecific.py
+++ b/magpurify/conspecific.py
@@ -9,7 +9,7 @@ from . import utility
 
 def fetch_args():
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage=argparse.SUPPRESS,
         description="MAGpurify: conspecific module: identify contigs that fail to align to closely related genomes",
     )
@@ -24,13 +24,11 @@ def fetch_args():
         '--threads',
         type=int,
         default=1,
-        metavar='INT',
         help="""Number of CPUs to use (default=1)""",
     )
     parser.add_argument(
         '--mash-sketch',
         type=str,
-        metavar='PATH',
         required=True,
         help="""Path to Mash sketch of reference genomes""",
     )
@@ -38,48 +36,41 @@ def fetch_args():
         '--mash-dist',
         type=float,
         default=0.05,
-        metavar='FLOAT',
         help="Mash distance to reference genomes (default=0.05)",
     )
     parser.add_argument(
         '--max-genomes',
         type=int,
         default=25,
-        metavar='INT',
         help="Max number of genomes to use (default=25)",
     )
     parser.add_argument(
         '--min-genomes',
         type=int,
         default=1,
-        metavar='INT',
         help="Min number of genomes to use (default=1)",
     )
     parser.add_argument(
         '--contig-aln',
         type=float,
         default=0.50,
-        metavar='FLOAT',
         help="Minimum fraction of contig aligned to reference (default=0.50)",
     )
     parser.add_argument(
         '--contig-pid',
         type=float,
         default=95.0,
-        metavar='FLOAT',
         help="Minimum percent identity of contig aligned to reference (default=95.0)",
     )
     parser.add_argument(
         '--hit-rate',
         type=float,
         default=0.00,
-        metavar='FLOAT',
         help="Hit rate for flagging contigs (default=0.00)",
     )
     parser.add_argument(
         '--exclude',
         default='',
-        metavar='STR',
         help="Comma-separated list of references to exclude",
     )
     args = vars(parser.parse_args())
@@ -230,7 +221,7 @@ def main():
     print("   contig features: %s" % out)
     print("\n## Identifying contigs with no conspecific alignments")
     flagged = flag_contigs(args, contigs)
-    out = '%s/flagged_contigs' % args['tmp_dir']
+    out = f"{args['tmp_dir']}/flagged_contigs"
     with open(out, 'w') as f:
         for contig in flagged_contigs:
             f.write(contig + '\n')

--- a/magpurify/conspecific.py
+++ b/magpurify/conspecific.py
@@ -13,106 +13,101 @@ def fetch_args():
         usage=argparse.SUPPRESS,
         description="MAGpurify: conspecific module: identify contigs that fail to align to closely related genomes",
     )
-    parser.add_argument('program', help=argparse.SUPPRESS)
-    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument("program", help=argparse.SUPPRESS)
+    parser.add_argument("fna", type=str, help="""Path to input genome in FASTA format""")
     parser.add_argument(
-        'out',
+        "out",
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
     parser.add_argument(
-        '--threads',
-        type=int,
-        default=1,
-        help="""Number of CPUs to use (default=1)""",
+        "--threads", type=int, default=1, help="""Number of CPUs to use (default=1)""",
     )
     parser.add_argument(
-        '--mash-sketch',
+        "--mash-sketch",
         type=str,
         required=True,
         help="""Path to Mash sketch of reference genomes""",
     )
     parser.add_argument(
-        '--mash-dist',
+        "--mash-dist",
         type=float,
         default=0.05,
         help="Mash distance to reference genomes (default=0.05)",
     )
     parser.add_argument(
-        '--max-genomes',
+        "--max-genomes",
         type=int,
         default=25,
         help="Max number of genomes to use (default=25)",
     )
     parser.add_argument(
-        '--min-genomes',
+        "--min-genomes",
         type=int,
         default=1,
         help="Min number of genomes to use (default=1)",
     )
     parser.add_argument(
-        '--contig-aln',
+        "--contig-aln",
         type=float,
         default=0.50,
         help="Minimum fraction of contig aligned to reference (default=0.50)",
     )
     parser.add_argument(
-        '--contig-pid',
+        "--contig-pid",
         type=float,
         default=95.0,
         help="Minimum percent identity of contig aligned to reference (default=95.0)",
     )
     parser.add_argument(
-        '--hit-rate',
+        "--hit-rate",
         type=float,
         default=0.00,
         help="Hit rate for flagging contigs (default=0.00)",
     )
     parser.add_argument(
-        '--exclude',
-        default='',
-        help="Comma-separated list of references to exclude",
+        "--exclude", default="", help="Comma-separated list of references to exclude",
     )
     args = vars(parser.parse_args())
-    args['exclude'] = args['exclude'].split(',')
+    args["exclude"] = args["exclude"].split(",")
     return args
 
 
 def run_mash(mash_sketch, fna_path, tmp_dir, threads=1):
-    out_path = f'{tmp_dir}/mash.dist'
+    out_path = f"{tmp_dir}/mash.dist"
     command = f"mash dist -p {threads} -d 0.25 {fna_path} {mash_sketch} > {out_path}"
     out, err = utility.run_process(command)
-    with open(tmp_dir + '/id_map.tsv', 'w') as f:
+    with open(tmp_dir + "/id_map.tsv", "w") as f:
         for id, rec in enumerate(utility.parse_mash(out_path)):
-            f.write(str(id) + '\t' + rec['target'] + '\n')
+            f.write(str(id) + "\t" + rec["target"] + "\n")
 
 
 def find_conspecific(tmp_dir, max_dist, exclude):
     targets = []
-    for rec in utility.parse_mash(f'{tmp_dir}/mash.dist'):
-        if rec['query'] == rec['target']:
+    for rec in utility.parse_mash(f"{tmp_dir}/mash.dist"):
+        if rec["query"] == rec["target"]:
             continue
-        elif rec['dist'] > max_dist:
+        elif rec["dist"] > max_dist:
             continue
-        elif rec['pvalue'] > 1e-3:
+        elif rec["pvalue"] > 1e-3:
             continue
-        elif rec['target'] in exclude:
+        elif rec["target"] in exclude:
             continue
         else:
-            targets.append([rec['target'], rec['dist']])
+            targets.append([rec["target"], rec["dist"]])
     targets = sorted(targets, key=itemgetter(1))
     return targets
 
 
 def blastn(query, target, outdir, id):
-    out_path = outdir + '/' + id + '.m8'
+    out_path = outdir + "/" + id + ".m8"
     if not os.path.exists(out_path):
         cmd = "blastn -outfmt '6 std qlen slen' "
         cmd += "-max_target_seqs 1 -max_hsps 1 "
         cmd += f"-query {query} -subject {target} "
         out, err = utility.run_process(cmd)
         out = out.decode("utf-8")
-        open(out_path, 'w').write(out)
+        open(out_path, "w").write(out)
     else:
         out = open(out_path).read()
     return out
@@ -120,25 +115,25 @@ def blastn(query, target, outdir, id):
 
 def id_blast_hits(blast_out, min_aln, min_pid):
     blast_hits = set([])
-    for rec in utility.parse_blast(blast_out, type='string'):
-        if rec['qcov'] < min_aln:
+    for rec in utility.parse_blast(blast_out, type="string"):
+        if rec["qcov"] < min_aln:
             continue
-        elif rec['pid'] < min_pid:
+        elif rec["pid"] < min_pid:
             continue
         else:
-            blast_hits.add(rec['qname'])
+            blast_hits.add(rec["qname"])
     return blast_hits
 
 
 def align_contigs(args, genomes):
     target_to_id = {}
-    for line in open(args['tmp_dir'] + '/id_map.tsv'):
+    for line in open(args["tmp_dir"] + "/id_map.tsv"):
         id, target = line.split()
         target_to_id[target] = id
     alignments = []
     for genome_path, mash_dist in genomes:
         blast_out = blastn(
-            args['fna'], genome_path, args['tmp_dir'], target_to_id[target]
+            args["fna"], genome_path, args["tmp_dir"], target_to_id[target]
         )
         alignments.append(blast_out)
     return alignments
@@ -147,25 +142,25 @@ def align_contigs(args, genomes):
 def find_contig_targets(args, genomes, alignments):
     contigs = dict(
         [
-            (id, {'hits': 0, 'len': len(seq), 'genomes': []})
-            for id, seq in utility.parse_fasta(args['fna'])
+            (id, {"hits": 0, "len": len(seq), "genomes": []})
+            for id, seq in utility.parse_fasta(args["fna"])
         ]
     )
     for genome, alns in zip(genomes, alignments):
-        hits = id_blast_hits(alns, args['contig_aln'], args['contig_pid'])
+        hits = id_blast_hits(alns, args["contig_aln"], args["contig_pid"])
         for contig in hits:
-            contigs[contig]['hits'] += 1
-            contigs[contig]['genomes'].append(genome[0])
+            contigs[contig]["hits"] += 1
+            contigs[contig]["genomes"].append(genome[0])
     for id in contigs:
-        hit_rate = contigs[id]['hits'] / float(len(alignments))
-        contigs[id]['hit_rate'] = hit_rate
+        hit_rate = contigs[id]["hits"] / float(len(alignments))
+        contigs[id]["hit_rate"] = hit_rate
     return contigs
 
 
 def flag_contigs(args, contigs):
     flagged = []
     for id in contigs:
-        if contigs[id]['hit_rate'] > args['hit_rate']:
+        if contigs[id]["hit_rate"] > args["hit_rate"]:
             continue
         else:
             flagged.append(id)
@@ -176,48 +171,48 @@ def main():
     args = fetch_args()
     utility.add_tmp_dir(args)
     utility.check_input(args)
-    utility.check_dependencies(['mash'])
-    if not os.path.exists(args['mash_sketch']):
+    utility.check_dependencies(["mash"])
+    if not os.path.exists(args["mash_sketch"]):
         sys.exit(f"\nError: mash sketch '{args['mash_sketch']}' not found\n")
     print("\n## Finding conspecific genomes in database")
-    run_mash(args['mash_sketch'], args['fna'], args['tmp_dir'], args['threads'])
-    genomes = find_conspecific(args['tmp_dir'], args['mash_dist'], args['exclude'])
+    run_mash(args["mash_sketch"], args["fna"], args["tmp_dir"], args["threads"])
+    genomes = find_conspecific(args["tmp_dir"], args["mash_dist"], args["exclude"])
     print(f"   {len(genomes)} genomes within {args['mash_dist']} mash-dist")
     out = f"{args['tmp_dir']}/conspecific.list"
-    with open(out, 'w') as f:
-        f.write('genome_id\tmash_dist\n')
+    with open(out, "w") as f:
+        f.write("genome_id\tmash_dist\n")
         for genome_id, mash_dist in genomes:
-            f.write(genome_id + '\t' + str(mash_dist) + '\n')
+            f.write(genome_id + "\t" + str(mash_dist) + "\n")
     print(f"   list of genomes: {out}")
     print(f"   mash output: {args['tmp_dir']}/mash.dist")
-    if len(genomes) < args['min_genomes']:
+    if len(genomes) < args["min_genomes"]:
         sys.exit("\nError: insufficient number of conspecific genomes\n")
-    if len(genomes) > args['max_genomes']:
+    if len(genomes) > args["max_genomes"]:
         print(f"\n## Selecting top {args['max_genomes']} most-similar genomes")
-        genomes = genomes[0 : args['max_genomes']]
+        genomes = genomes[0 : args["max_genomes"]]
         out = f"{args['tmp_dir']}/conspecific_subset.list"
-        with open(out, 'w') as f:
-            f.write('genome_id\tmash_dist\n')
+        with open(out, "w") as f:
+            f.write("genome_id\tmash_dist\n")
             for genome_id, mash_dist in genomes:
-                f.write(genome_id + '\t' + str(mash_dist) + '\n')
+                f.write(genome_id + "\t" + str(mash_dist) + "\n")
         print(f"   list of genomes: {out}")
     print("\n## Performing pairwise alignment of contigs in bin to database genomes")
     alignments = align_contigs(args, genomes)
-    num_alns = sum(len(_.split('\n')) for _ in alignments)
+    num_alns = sum(len(_.split("\n")) for _ in alignments)
     print(f"   total alignments: {num_alns}")
     print("\n## Summarizing alignments")
     contigs = find_contig_targets(args, genomes, alignments)
     out = f"{args['tmp_dir']}/contig_hits.tsv"
-    with open(out, 'w') as f:
-        f.write('contig_id\tlength\talignment_rate\n')
+    with open(out, "w") as f:
+        f.write("contig_id\tlength\talignment_rate\n")
         for contig, values in contigs.items():
-            row = [contig, str(values['len']), f"{values['hits']}/{len(genomes)}"]
-            f.write('\t'.join(row) + '\n')
+            row = [contig, str(values["len"]), f"{values['hits']}/{len(genomes)}"]
+            f.write("\t".join(row) + "\n")
     print(f"   contig features: {out}")
     print("\n## Identifying contigs with no conspecific alignments")
     flagged = flag_contigs(args, contigs)
     out = f"{args['tmp_dir']}/flagged_contigs"
-    with open(out, 'w') as f:
+    with open(out, "w") as f:
         for contig in flagged_contigs:
-            f.write(contig + '\n')
+            f.write(contig + "\n")
     print(f"   {len(flagged)} flagged contigs: {out}")

--- a/magpurify/contam.py
+++ b/magpurify/contam.py
@@ -54,16 +54,16 @@ By default, the IMAGEN_DB environmental variable is used""",
 
 def run_blastn(query, db, out, threads, qcov=25, pid=98, evalue=1e-5):
     cmd = "blastn "
-    cmd += "-query %s " % query
-    cmd += "-db %s " % db
-    cmd += "-out %s " % out
+    cmd += f"-query {query} "
+    cmd += f"-db {db} "
+    cmd += f"-out {out} "
     cmd += "-outfmt '6 std qlen slen' "
     cmd += "-max_target_seqs 1 "
     cmd += "-max_hsps 1 "
-    cmd += "-qcov_hsp_perc %s " % qcov
-    cmd += "-perc_identity %s " % pid
-    cmd += "-evalue %s " % evalue
-    cmd += "-num_threads %s " % threads
+    cmd += f"-qcov_hsp_perc {qcov} "
+    cmd += f"-perc_identity {pid} "
+    cmd += f"-evalue {evalue} "
+    cmd += f"-num_threads {threads} "
     utility.run_process(cmd)
 
 
@@ -76,8 +76,8 @@ def main():
     utility.add_tmp_dir(args)
     print("\n## Searching database with BLASTN")
     for target in ['hg38', 'phix']:
-        db = '%s/known-contam/%s/%s' % (args['db'], target, target)
-        out = '%s/%s.m8' % (args['tmp_dir'], target)
+        db = f"{args['db']}/known-contam/{target}/{target}"
+        out = f"{args['tmp_dir']}/{target}.m8"
         run_blastn(
             args['fna'],
             db,
@@ -90,7 +90,7 @@ def main():
     print("\n## Identifying contigs with hits to db")
     flagged = set([])
     for target in ['hg38', 'phix']:
-        out = '%s/%s.m8' % (args['tmp_dir'], target)
+        out = f"{args['tmp_dir']}/{target}.m8"
         for r in utility.parse_blast(out):
             flagged.add(r['qname'])
     flagged = list(flagged)

--- a/magpurify/contam.py
+++ b/magpurify/contam.py
@@ -8,7 +8,7 @@ from . import utility
 
 def fetch_args():
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage=argparse.SUPPRESS,
         description="MAGpurify: known-contam module: find contigs that match a database of known contaminants",
     )
@@ -73,9 +73,7 @@ def main():
     utility.check_input(args)
     utility.check_dependencies(['blastn'])
     utility.check_database(args)
-    tmp_dir = '%s/%s' % (args['out'], args['program'])
-    if not os.path.exists(args['tmp_dir']):
-        os.makedirs(args['tmp_dir'])
+    utility.add_tmp_dir(args)
     print("\n## Searching database with BLASTN")
     for target in ['hg38', 'phix']:
         db = '%s/known-contam/%s/%s' % (args['db'], target, target)
@@ -96,7 +94,7 @@ def main():
         for r in utility.parse_blast(out):
             flagged.add(r['qname'])
     flagged = list(flagged)
-    out = '%s/flagged_contigs' % args['tmp_dir']
+    out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
     with open(out, 'w') as f:
         for contig in flagged:

--- a/magpurify/contam.py
+++ b/magpurify/contam.py
@@ -12,38 +12,38 @@ def fetch_args():
         usage=argparse.SUPPRESS,
         description="MAGpurify: known-contam module: find contigs that match a database of known contaminants",
     )
-    parser.add_argument('program', help=argparse.SUPPRESS)
-    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument("program", help=argparse.SUPPRESS)
+    parser.add_argument("fna", type=str, help="""Path to input genome in FASTA format""")
     parser.add_argument(
-        'out',
+        "out",
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
     parser.add_argument(
-        '-t',
-        dest='threads',
+        "-t",
+        dest="threads",
         type=int,
         default=1,
         help="""Number of CPUs to use (default=1)""",
     )
     parser.add_argument(
-        '-d',
-        dest='db',
+        "-d",
+        dest="db",
         type=str,
         help="""Path to reference database
 By default, the IMAGEN_DB environmental variable is used""",
     )
     parser.add_argument(
-        '--pid',
+        "--pid",
         type=float,
         default=98,
         help="""Minimum %% identity to reference (default=98)""",
     )
     parser.add_argument(
-        '--evalue', type=float, default=1e-5, help="""Maximum evalue (default=1e-5)"""
+        "--evalue", type=float, default=1e-5, help="""Maximum evalue (default=1e-5)"""
     )
     parser.add_argument(
-        '--qcov',
+        "--qcov",
         type=float,
         default=25,
         help="""Minimum percent query coverage (default=25)""",
@@ -71,31 +71,31 @@ def main():
     args = fetch_args()
     utility.add_tmp_dir(args)
     utility.check_input(args)
-    utility.check_dependencies(['blastn'])
+    utility.check_dependencies(["blastn"])
     utility.check_database(args)
     utility.add_tmp_dir(args)
     print("\n## Searching database with BLASTN")
-    for target in ['hg38', 'phix']:
+    for target in ["hg38", "phix"]:
         db = f"{args['db']}/known-contam/{target}/{target}"
         out = f"{args['tmp_dir']}/{target}.m8"
         run_blastn(
-            args['fna'],
+            args["fna"],
             db,
             out,
-            args['threads'],
-            args['qcov'],
-            args['pid'],
-            args['evalue'],
+            args["threads"],
+            args["qcov"],
+            args["pid"],
+            args["evalue"],
         )
     print("\n## Identifying contigs with hits to db")
     flagged = set([])
-    for target in ['hg38', 'phix']:
+    for target in ["hg38", "phix"]:
         out = f"{args['tmp_dir']}/{target}.m8"
         for r in utility.parse_blast(out):
-            flagged.add(r['qname'])
+            flagged.add(r["qname"])
     flagged = list(flagged)
     out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
-    with open(out, 'w') as f:
+    with open(out, "w") as f:
         for contig in flagged:
-            f.write(contig + '\n')
+            f.write(contig + "\n")

--- a/magpurify/coverage.py
+++ b/magpurify/coverage.py
@@ -12,22 +12,22 @@ def fetch_args():
         usage=argparse.SUPPRESS,
         description="MAGpurify: coverage module: find contigs with outlier coverage profile",
     )
-    parser.add_argument('program', help=argparse.SUPPRESS)
-    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument("program", help=argparse.SUPPRESS)
+    parser.add_argument("fna", type=str, help="""Path to input genome in FASTA format""")
     parser.add_argument(
-        'out',
+        "out",
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
     parser.add_argument(
-        '--bams',
-        nargs='+',
+        "--bams",
+        nargs="+",
         type=str,
         required=True,
         help="""Paths to input sorted BAM files""",
     )
     parser.add_argument(
-        '--max-deviation',
+        "--max-deviation",
         type=float,
         default=5.0,
         help="""Contigs with coverage greater than [max-deviation * mean coverage] or less than [(1/max-deviation) * mean coverage] will be flagged as outliers""",
@@ -40,13 +40,13 @@ def main():
     args = fetch_args()
     utility.add_tmp_dir(args)
     utility.check_input(args)
-    utility.check_dependencies(['coverm'])
+    utility.check_dependencies(["coverm"])
     print("\n## Computing contig coverage")
-    utility.run_coverm(args['bams'], args['tmp_dir'])
+    utility.run_coverm(args["bams"], args["tmp_dir"])
     coverage_df = pd.read_csv(f"{args['tmp_dir']}/coverage.tsv", sep="\t", index_col=0)
     print("\n## Identifying outlier contigs")
     mag_id_list = []
-    for id, seq in utility.parse_fasta(args['fna']):
+    for id, seq in utility.parse_fasta(args["fna"]):
         mag_id_list.append(id)
     mag_coverage_df = coverage_df.loc[mag_id_list]
     largest_mean_coverage_sample = mag_coverage_df.mean(axis=0).idxmax()
@@ -55,12 +55,13 @@ def main():
         sys.exit(
             "\nError: The average coverage is less than 1 in all the supplied BAM files"
         )
-    outliers = ((mag_coverage_df / mag_coverage_df.mean()) >= args['max_deviation']) | (
-        (mag_coverage_df / mag_coverage_df.mean()) <= 1 / args['max_deviation']
+    outliers = ((mag_coverage_df / mag_coverage_df.mean()) >= args["max_deviation"]) | (
+        (mag_coverage_df / mag_coverage_df.mean()) <= 1 / args["max_deviation"]
     )
     flagged = mag_coverage_df.loc[outliers].index.tolist()
     out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
-    with open(out, 'w') as f:
+    with open(out, "w") as f:
         for contig in flagged:
-            f.write(contig + '\n')
+            f.write(contig + "\n")
+

--- a/magpurify/coverage.py
+++ b/magpurify/coverage.py
@@ -1,2 +1,66 @@
 #!/usr/bin/env python
 
+import argparse
+import sys
+import pandas as pd
+from . import utility
+
+
+def fetch_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        usage=argparse.SUPPRESS,
+        description="MAGpurify: coverage module: find contigs with outlier coverage profile",
+    )
+    parser.add_argument('program', help=argparse.SUPPRESS)
+    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument(
+        'out',
+        type=str,
+        help="""Output directory to store results and intermediate files""",
+    )
+    parser.add_argument(
+        '--bams',
+        nargs='+',
+        type=str,
+        required=True,
+        help="""Paths to input sorted BAM files""",
+    )
+    parser.add_argument(
+        '--max-deviation',
+        type=float,
+        default=5.0,
+        help="""Contigs with coverage greater than [max-deviation * mean coverage] or less than [(1/max-deviation) * mean coverage] will be flagged as outliers""",
+    )
+    args = vars(parser.parse_args())
+    return args
+
+
+def main():
+    args = fetch_args()
+    utility.add_tmp_dir(args)
+    utility.check_input(args)
+    utility.check_dependencies(['coverm'])
+    print("\n## Computing contig coverage")
+    utility.run_coverm(args['bams'], args['tmp_dir'])
+    coverage_df = pd.read_csv(f"{args['tmp_dir']}/coverage.tsv", sep="\t", index_col=0)
+    print("\n## Identifying outlier contigs")
+    mag_id_list = []
+    for id, seq in utility.parse_fasta(args['fna']):
+        mag_id_list.append(id)
+    mag_coverage_df = coverage_df.loc[mag_id_list]
+    largest_mean_coverage_sample = mag_coverage_df.mean(axis=0).idxmax()
+    mag_coverage_df = mag_coverage_df.loc[:, largest_mean_coverage_sample]
+    if mag_coverage_df.mean() < 1:
+        sys.exit(
+            "\nError: The average coverage is less than 1 in all the supplied BAM files"
+        )
+    outliers = ((mag_coverage_df / mag_coverage_df.mean()) >= args['max_deviation']) | (
+        (mag_coverage_df / mag_coverage_df.mean()) <= 1 / args['max_deviation']
+    )
+    flagged = mag_coverage_df.loc[outliers].index.tolist()
+    out = f"{args['tmp_dir']}/flagged_contigs"
+    print(f"   {len(flagged)} flagged contigs: {out}")
+    with open(out, 'w') as f:
+        for contig in flagged:
+            f.write(contig + '\n')

--- a/magpurify/coverage.py
+++ b/magpurify/coverage.py
@@ -50,6 +50,10 @@ def main():
         mag_id_list.append(id)
     mag_coverage_df = coverage_df.loc[mag_id_list]
     largest_mean_coverage_sample = mag_coverage_df.mean(axis=0).idxmax()
+    if mag_coverage_df.shape[1] > 1:
+        print(
+            f"\n## Sample being used for outlier detection: {largest_mean_coverage_sample.split()[0]}"
+        )
     mag_coverage_df = mag_coverage_df.loc[:, largest_mean_coverage_sample]
     if mag_coverage_df.mean() < 1:
         sys.exit(

--- a/magpurify/csmg.py
+++ b/magpurify/csmg.py
@@ -22,7 +22,7 @@ rank_names = {
 
 def fetch_args():
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage=argparse.SUPPRESS,
         description="MAGpurify: clade-markers module: find taxonomic discordant contigs using db of clade-specific marker genes",
     )
@@ -92,15 +92,6 @@ By default, the MAGPURIFY environmental variable is used""",
     return args
 
 
-def add_defaults(args):
-    args['lowest_rank'] = None
-    args['min_genes'] = None
-    args['min_gene_fract'] = 0.0
-    args['min_contig_fract'] = 0.75
-    args['min_bin_fract'] = 0.6
-    args['exclude_clades'] = None
-
-
 def read_ref_taxonomy(db_dir):
     ref_taxonomy = {}
     inpath = '%s/clade-markers/taxonomy.tsv' % db_dir
@@ -167,7 +158,6 @@ class Bin:
         self.taxonomy = [None]
         self.tagged_length = 0
         self.tagged_genes = 0
-
     def classify(
         self,
         contigs,
@@ -177,21 +167,17 @@ class Bin:
         min_genes,
         lowest_rank,
     ):
-
         for rank in ranks:
-
             count_genes = collections.defaultdict(int)
             for contig in contigs.values():
                 for gene in contig.genes:
                     if gene.taxa[rank]:
                         count_genes[gene.taxa[rank]] += 1
-
             count_length = collections.defaultdict(int)
             for contig in contigs.values():
                 contig_taxon = contig.cons_taxa[rank]
                 if contig_taxon is not None:
                     count_length[contig_taxon] += contig.length
-
             if sum(count_length.values()) > 0:
                 cons_taxon = sorted(
                     count_length.items(), key=operator.itemgetter(1), reverse=True
@@ -208,7 +194,6 @@ class Bin:
                 gene_fract = 0.0
                 contig_fract = 0.0
                 bin_fract = 0.0
-
             if bin_fract < min_bin_fract:
                 continue
             elif contig_fract < min_contig_fract:
@@ -224,7 +209,6 @@ class Bin:
                 self.bin_fract = bin_fract
                 self.tagged_genes = sum(count_genes.values())
                 self.tagged_length = sum(count_length.values())
-
             if lowest_rank and rank == lowest_rank:
                 break
 
@@ -351,7 +335,7 @@ def main():
     for contig in contigs.values():
         if contig.flagged:
             flagged.append(contig.id)
-    out = '%s/flagged_contigs' % args['tmp_dir']
+    out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
     with open(out, 'w') as f:
         for contig in flagged:

--- a/magpurify/csmg.py
+++ b/magpurify/csmg.py
@@ -94,7 +94,7 @@ By default, the MAGPURIFY environmental variable is used""",
 
 def read_ref_taxonomy(db_dir):
     ref_taxonomy = {}
-    inpath = '%s/clade-markers/taxonomy.tsv' % db_dir
+    inpath = f'{db_dir}/clade-markers/taxonomy.tsv'
     for line in open(inpath):
         ref_id, taxonomy = line.rstrip().split()
         ref_taxonomy[ref_id] = taxonomy
@@ -239,12 +239,12 @@ def main():
         }
     print("\n## Calling genes with Prodigal")
     utility.run_prodigal(args['fna'], args['tmp_dir'])
-    print("   all genes: %s/genes.[ffn|faa]" % args['tmp_dir'])
+    print(f"   all genes: {args['tmp_dir']}/genes.[ffn|faa]")
     print(
         "\n## Performing pairwise alignment of genes against MetaPhlan2 db of clade-specific genes"
     )
     utility.run_lastal(args['db'], args['tmp_dir'], args['threads'])
-    print("   alignments: %s/genes.m8" % args['tmp_dir'])
+    print(f"   alignments: {args['tmp_dir']}/genes.m8")
 
     print("\n## Finding top hits to db")
     genes = {}
@@ -286,7 +286,7 @@ def main():
             gene.taxa[rank] = ref_taxon
             counts[rank] += 1
     for rank in ranks:
-        print("   %s: %s classified genes" % (rank_names[rank], counts[rank]))
+        print(f"   {rank_names[rank]}: {counts[rank]} classified genes")
     print("\n## Taxonomically classifying contigs")
     contigs = {}
     for id, seq in utility.parse_fasta(args['fna']):
@@ -309,7 +309,7 @@ def main():
                 counts[rank] += 1
     print("   total contigs: %s" % len(contigs))
     for rank in ranks:
-        print("   %s: %s classified contigs" % (rank_names[rank], counts[rank]))
+        print(f"   {rank_names[rank]}: {counts[rank]} classified contigs")
 
     print("\n## Taxonomically classifying genome")
     bin = Bin()
@@ -321,7 +321,7 @@ def main():
         args['min_genes'],
         args['lowest_rank'],
     )
-    print("   consensus taxon: %s" % bin.cons_taxon)
+    print(f"   consensus taxon: {bin.cons_taxon}")
     print("\n## Identifying taxonomically discordant contigs")
     if bin.cons_taxon is not None:
         bin.rank_index = (

--- a/magpurify/csmg.py
+++ b/magpurify/csmg.py
@@ -8,15 +8,15 @@ import os
 import sys
 from . import utility
 
-ranks = ['k', 'p', 'c', 'o', 'f', 'g', 's']
+ranks = ["k", "p", "c", "o", "f", "g", "s"]
 rank_names = {
-    'k': 'kingdom',
-    'p': 'phylum',
-    'c': 'class',
-    'o': 'order',
-    'f': 'family',
-    'g': 'genus',
-    's': 'species',
+    "k": "kingdom",
+    "p": "phylum",
+    "c": "class",
+    "o": "order",
+    "f": "family",
+    "g": "genus",
+    "s": "species",
 }
 
 
@@ -26,65 +26,65 @@ def fetch_args():
         usage=argparse.SUPPRESS,
         description="MAGpurify: clade-markers module: find taxonomic discordant contigs using db of clade-specific marker genes",
     )
-    parser.add_argument('program', help=argparse.SUPPRESS)
-    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument("program", help=argparse.SUPPRESS)
+    parser.add_argument("fna", type=str, help="""Path to input genome in FASTA format""")
     parser.add_argument(
-        'out',
+        "out",
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
     parser.add_argument(
-        '-t',
-        dest='threads',
+        "-t",
+        dest="threads",
         type=int,
         default=1,
         help="""Number of CPUs to use (default=1)""",
     )
     parser.add_argument(
-        '-d',
-        dest='db',
+        "-d",
+        dest="db",
         type=str,
         help="""Path to reference database
 By default, the MAGPURIFY environmental variable is used""",
     )
     parser.add_argument(
-        '-e',
-        '--exclude_clades',
+        "-e",
+        "--exclude_clades",
         type=str,
         help="""Comma separated list of clades to exclude (ex: s__Variovorax_sp_CF313)""",
     )
     parser.add_argument(
-        '-b',
-        '--min_bin_fract',
+        "-b",
+        "--min_bin_fract",
         type=float,
         default=0.6,
         help="""Min fraction of bin length supported by contigs that agree with consensus taxonomy (default=0.6)""",
     )
     parser.add_argument(
-        '-c',
-        '--min_contig_fract',
+        "-c",
+        "--min_contig_fract",
         type=float,
         default=0.75,
         help="""Min fraction of classified contig length that agree with consensus taxonomy (default=0.75)""",
     )
     parser.add_argument(
-        '-g',
-        '--min_gene_fract',
+        "-g",
+        "--min_gene_fract",
         type=float,
         default=0.0,
         help="""Min fraction of classified genes that agree with consensus taxonomy (default=0.0)""",
     )
     parser.add_argument(
-        '-m',
-        '--min_genes',
+        "-m",
+        "--min_genes",
         type=float,
         default=None,
         help="""Min number of genes that agree with consensus taxonomy (default=rank-specific-cutoffs)""",
     )
     parser.add_argument(
-        '-l',
-        '--lowest_rank',
-        choices=['s', 'g', 'f', 'o', 'c', 'p', 'k'],
+        "-l",
+        "--lowest_rank",
+        choices=["s", "g", "f", "o", "c", "p", "k"],
         help="""Lowest rank for bin classification""",
     )
 
@@ -94,7 +94,7 @@ By default, the MAGPURIFY environmental variable is used""",
 
 def read_ref_taxonomy(db_dir):
     ref_taxonomy = {}
-    inpath = f'{db_dir}/clade-markers/taxonomy.tsv'
+    inpath = f"{db_dir}/clade-markers/taxonomy.tsv"
     for line in open(inpath):
         ref_id, taxonomy = line.rstrip().split()
         ref_taxonomy[ref_id] = taxonomy
@@ -103,7 +103,7 @@ def read_ref_taxonomy(db_dir):
 
 def flag_contigs(contigs, bin):
     for bin_taxon in bin.taxonomy:
-        bin_rank = bin_taxon.split('__')[0]
+        bin_rank = bin_taxon.split("__")[0]
         for contig in contigs.values():
             contig_taxa = [
                 gene.taxa[bin_rank] for gene in contig.genes if gene.taxa[bin_rank]
@@ -158,6 +158,7 @@ class Bin:
         self.taxonomy = [None]
         self.tagged_length = 0
         self.tagged_genes = 0
+
     def classify(
         self,
         contigs,
@@ -190,7 +191,7 @@ class Bin:
                     c.length for c in contigs.values()
                 )
             else:
-                cons_taxon = 'NA'
+                cons_taxon = "NA"
                 gene_fract = 0.0
                 contig_fract = 0.0
                 bin_fract = 0.0
@@ -219,69 +220,69 @@ def main():
     utility.check_input(args)
     utility.check_database(args)
     print("\n## Reading database info")
-    ref_taxonomy = read_ref_taxonomy(args['db'])
+    ref_taxonomy = read_ref_taxonomy(args["db"])
     taxon_to_taxonomy = {}
     for taxonomy in set(ref_taxonomy.values()):
-        for taxon in taxonomy.split('|'):
+        for taxon in taxonomy.split("|"):
             taxon_to_taxonomy[taxon] = taxonomy
-    min_pid = {'k': 57, 'p': 77, 'c': 82, 'o': 86, 'f': 87, 'g': 91, 's': 96}
-    if args['min_genes'] is not None:
-        args['min_genes'] = dict([(r, args['min_genes']) for r in ranks])
+    min_pid = {"k": 57, "p": 77, "c": 82, "o": 86, "f": 87, "g": 91, "s": 96}
+    if args["min_genes"] is not None:
+        args["min_genes"] = dict([(r, args["min_genes"]) for r in ranks])
     else:
-        args['min_genes'] = {
-            'k': 237,
-            'p': 44,
-            'c': 30,
-            'o': 24,
-            'f': 22,
-            'g': 20,
-            's': 19,
+        args["min_genes"] = {
+            "k": 237,
+            "p": 44,
+            "c": 30,
+            "o": 24,
+            "f": 22,
+            "g": 20,
+            "s": 19,
         }
     print("\n## Calling genes with Prodigal")
-    utility.run_prodigal(args['fna'], args['tmp_dir'])
+    utility.run_prodigal(args["fna"], args["tmp_dir"])
     print(f"   all genes: {args['tmp_dir']}/genes.[ffn|faa]")
     print(
         "\n## Performing pairwise alignment of genes against MetaPhlan2 db of clade-specific genes"
     )
-    utility.run_lastal(args['db'], args['tmp_dir'], args['threads'])
+    utility.run_lastal(args["db"], args["tmp_dir"], args["threads"])
     print(f"   alignments: {args['tmp_dir']}/genes.m8")
 
     print("\n## Finding top hits to db")
     genes = {}
-    for aln in utility.parse_last(args['tmp_dir'] + '/genes.m8'):
+    for aln in utility.parse_last(args["tmp_dir"] + "/genes.m8"):
         # clade exclusion
-        ref_taxa = ref_taxonomy[aln['tid']].split('|')
-        if args['exclude_clades'] and any(
-            [taxon in ref_taxa for taxon in args['exclude_clades'].split(',')]
+        ref_taxa = ref_taxonomy[aln["tid"]].split("|")
+        if args["exclude_clades"] and any(
+            [taxon in ref_taxa for taxon in args["exclude_clades"].split(",")]
         ):
             continue
         # initialize gene
-        if aln['qid'] not in genes:
-            genes[aln['qid']] = Gene()
-            genes[aln['qid']].id = aln['qid']
-            genes[aln['qid']].contig_id = aln['qid'].rsplit('_', 1)[0]
+        if aln["qid"] not in genes:
+            genes[aln["qid"]] = Gene()
+            genes[aln["qid"]].id = aln["qid"]
+            genes[aln["qid"]].contig_id = aln["qid"].rsplit("_", 1)[0]
 
         # get top alignments
-        if genes[aln['qid']].aln is None:
-            genes[aln['qid']].aln = aln
-            genes[aln['qid']].ref_taxa = ref_taxa
-        elif float(aln['score']) > float(genes[aln['qid']].aln['score']):
-            genes[aln['qid']].ref_taxa = ref_taxa
+        if genes[aln["qid"]].aln is None:
+            genes[aln["qid"]].aln = aln
+            genes[aln["qid"]].ref_taxa = ref_taxa
+        elif float(aln["score"]) > float(genes[aln["qid"]].aln["score"]):
+            genes[aln["qid"]].ref_taxa = ref_taxa
     print("   %s genes with a database hit" % len(genes))
     print("\n## Classifying genes at each taxonomic rank")
     counts = {}
     for gene in genes.values():
         for ref_taxon in gene.ref_taxa:
-            rank = ref_taxon.split('__')[0]
+            rank = ref_taxon.split("__")[0]
             if rank not in counts:
                 counts[rank] = 0
-            if rank == 't':
+            if rank == "t":
                 continue
-            elif float(gene.aln['pid']) < min_pid[rank]:
+            elif float(gene.aln["pid"]) < min_pid[rank]:
                 continue
-            elif gene.aln['qcov'] < 0.4:
+            elif gene.aln["qcov"] < 0.4:
                 continue
-            elif gene.aln['tcov'] < 0.4:
+            elif gene.aln["tcov"] < 0.4:
                 continue
             gene.taxa[rank] = ref_taxon
             counts[rank] += 1
@@ -289,7 +290,7 @@ def main():
         print(f"   {rank_names[rank]}: {counts[rank]} classified genes")
     print("\n## Taxonomically classifying contigs")
     contigs = {}
-    for id, seq in utility.parse_fasta(args['fna']):
+    for id, seq in utility.parse_fasta(args["fna"]):
         contigs[id] = Contig()
         contigs[id].id = id
         contigs[id].length = len(seq)
@@ -315,19 +316,19 @@ def main():
     bin = Bin()
     bin.classify(
         contigs,
-        args['min_bin_fract'],
-        args['min_contig_fract'],
-        args['min_gene_fract'],
-        args['min_genes'],
-        args['lowest_rank'],
+        args["min_bin_fract"],
+        args["min_contig_fract"],
+        args["min_gene_fract"],
+        args["min_genes"],
+        args["lowest_rank"],
     )
     print(f"   consensus taxon: {bin.cons_taxon}")
     print("\n## Identifying taxonomically discordant contigs")
     if bin.cons_taxon is not None:
         bin.rank_index = (
-            taxon_to_taxonomy[bin.cons_taxon].split('|').index(bin.cons_taxon)
+            taxon_to_taxonomy[bin.cons_taxon].split("|").index(bin.cons_taxon)
         )
-        bin.taxonomy = taxon_to_taxonomy[bin.cons_taxon].split('|')[
+        bin.taxonomy = taxon_to_taxonomy[bin.cons_taxon].split("|")[
             0 : bin.rank_index + 1
         ]
         flag_contigs(contigs, bin)
@@ -337,6 +338,7 @@ def main():
             flagged.append(contig.id)
     out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
-    with open(out, 'w') as f:
+    with open(out, "w") as f:
         for contig in flagged:
-            f.write(contig + '\n')
+            f.write(contig + "\n")
+

--- a/magpurify/gc.py
+++ b/magpurify/gc.py
@@ -10,7 +10,7 @@ from . import utility
 
 def fetch_args():
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage=argparse.SUPPRESS,
         description="MAGpurify: gc-content module: find contigs with outlier gc content",
     )
@@ -33,10 +33,6 @@ def fetch_args():
     )
     args = vars(parser.parse_args())
     return args
-
-
-def add_defaults(args):
-    args['cutoff'] = 15.75
 
 
 class Contig:
@@ -66,7 +62,7 @@ def main():
     for contig in contigs.values():
         if contig.values['delta'] > args['cutoff']:
             flagged.append(contig.id)
-    out = '%s/flagged_contigs' % args['tmp_dir']
+    out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
     with open(out, 'w') as f:
         for contig in flagged:

--- a/magpurify/gc.py
+++ b/magpurify/gc.py
@@ -14,22 +14,22 @@ def fetch_args():
         usage=argparse.SUPPRESS,
         description="MAGpurify: gc-content module: find contigs with outlier gc content",
     )
-    parser.add_argument('program', help=argparse.SUPPRESS)
-    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument("program", help=argparse.SUPPRESS)
+    parser.add_argument("fna", type=str, help="""Path to input genome in FASTA format""")
     parser.add_argument(
-        'out',
+        "out",
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
     parser.add_argument(
-        '-t',
-        dest='threads',
+        "-t",
+        dest="threads",
         type=int,
         default=1,
         help="""Number of CPUs to use (default=1)""",
     )
     parser.add_argument(
-        '--cutoff', type=float, default=15.75, help="""Cutoff (default=15.75)"""
+        "--cutoff", type=float, default=15.75, help="""Cutoff (default=15.75)"""
     )
     args = vars(parser.parse_args())
     return args
@@ -46,7 +46,7 @@ def main():
     utility.check_input(args)
     print("\n## Computing mean contig GC content")
     contigs = {}
-    for id, seq in utility.parse_fasta(args['fna']):
+    for id, seq in utility.parse_fasta(args["fna"]):
         contig = Contig()
         contig.id = id
         contig.seq = str(seq)
@@ -56,14 +56,14 @@ def main():
     print("\n## Computing per-contig deviation from mean")
     for contig in contigs.values():
         contig.values = {}
-        contig.values['delta'] = abs(contig.gc - mean)
+        contig.values["delta"] = abs(contig.gc - mean)
     print("\n## Identifying outlier contigs")
     flagged = []
     for contig in contigs.values():
-        if contig.values['delta'] > args['cutoff']:
+        if contig.values["delta"] > args["cutoff"]:
             flagged.append(contig.id)
     out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
-    with open(out, 'w') as f:
+    with open(out, "w") as f:
         for contig in flagged:
-            f.write(contig + '\n')
+            f.write(contig + "\n")

--- a/magpurify/tetra.py
+++ b/magpurify/tetra.py
@@ -17,22 +17,22 @@ def fetch_args():
         usage=argparse.SUPPRESS,
         description="MAGpurify: tetra-freq module: find contigs with outlier tetranucleotide frequency",
     )
-    parser.add_argument('program', help=argparse.SUPPRESS)
-    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument("program", help=argparse.SUPPRESS)
+    parser.add_argument("fna", type=str, help="""Path to input genome in FASTA format""")
     parser.add_argument(
-        'out',
+        "out",
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
     parser.add_argument(
-        '-t',
-        dest='threads',
+        "-t",
+        dest="threads",
         type=int,
         default=1,
         help="""Number of CPUs to use (default=1)""",
     )
     parser.add_argument(
-        '--cutoff', type=float, default=0.06, help="""Cutoff (default=0.06)"""
+        "--cutoff", type=float, default=0.06, help="""Cutoff (default=0.06)"""
     )
     args = vars(parser.parse_args())
     return args
@@ -41,7 +41,7 @@ def fetch_args():
 def init_kmers():
     tetra = {}
     for i in itertools.product("ACGT", repeat=4):
-        kmer_fwd = ''.join(i)
+        kmer_fwd = "".join(i)
         kmer_rev = utility.reverse_complement(kmer_fwd)
         if kmer_fwd in tetra:
             continue
@@ -62,12 +62,12 @@ def main():
     args = fetch_args()
     utility.add_tmp_dir(args)
     utility.check_input(args)
-    utility.check_dependencies(['blastn'])
+    utility.check_dependencies(["blastn"])
 
     print("\n## Counting tetranucleotides")
     # init data
     contigs = {}
-    for id, seq in utility.parse_fasta(args['fna']):
+    for id, seq in utility.parse_fasta(args["fna"]):
         contig = Contig()
         contig.id = id
         contig.seq = str(seq)
@@ -106,15 +106,15 @@ def main():
     for contig_id, contig_pc in zip(list(df.columns), pc1):
         contigs[contig_id].pc = contig_pc
         contigs[contig_id].values = {}
-        contigs[contig_id].values['delta'] = abs(contig_pc - mean_pc)
+        contigs[contig_id].values["delta"] = abs(contig_pc - mean_pc)
 
     print("\n## Identifying outlier contigs")
     flagged = []
     for contig in contigs.values():
-        if contig.values['delta'] > args['cutoff']:
+        if contig.values["delta"] > args["cutoff"]:
             flagged.append(contig.id)
     out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
-    with open(out, 'w') as f:
+    with open(out, "w") as f:
         for contig in flagged:
-            f.write(contig + '\n')
+            f.write(contig + "\n")

--- a/magpurify/tetra.py
+++ b/magpurify/tetra.py
@@ -13,7 +13,7 @@ from . import utility
 
 def fetch_args():
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage=argparse.SUPPRESS,
         description="MAGpurify: tetra-freq module: find contigs with outlier tetranucleotide frequency",
     )
@@ -36,10 +36,6 @@ def fetch_args():
     )
     args = vars(parser.parse_args())
     return args
-
-
-def add_defaults(args):
-    args['cutoff'] = 0.06
 
 
 def init_kmers():
@@ -117,7 +113,7 @@ def main():
     for contig in contigs.values():
         if contig.values['delta'] > args['cutoff']:
             flagged.append(contig.id)
-    out = '%s/flagged_contigs' % args['tmp_dir']
+    out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
     with open(out, 'w') as f:
         for contig in flagged:

--- a/magpurify/uscmg.py
+++ b/magpurify/uscmg.py
@@ -11,7 +11,7 @@ from . import utility
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage=argparse.SUPPRESS,
         description="MAGpurify: phylo-markers module: find taxonomic discordant contigs using db of phylogenetic marker genes",
     )
@@ -465,7 +465,7 @@ def main():
 
     print("\n## Finding taxonomic outliers")
     flagged = flag_contigs(args['db'], args['tmp_dir'], args)
-    out = '%s/flagged_contigs' % args['tmp_dir']
+    out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
     with open(out, 'w') as f:
         for contig in flagged:

--- a/magpurify/uscmg.py
+++ b/magpurify/uscmg.py
@@ -15,78 +15,78 @@ def parse_args():
         usage=argparse.SUPPRESS,
         description="MAGpurify: phylo-markers module: find taxonomic discordant contigs using db of phylogenetic marker genes",
     )
-    parser.add_argument('program', help=argparse.SUPPRESS)
-    parser.add_argument('fna', type=str, help="""Path to input genome in FASTA format""")
+    parser.add_argument("program", help=argparse.SUPPRESS)
+    parser.add_argument("fna", type=str, help="""Path to input genome in FASTA format""")
     parser.add_argument(
-        'out',
+        "out",
         type=str,
         help="""Output directory to store results and intermediate files""",
     )
     parser.add_argument(
-        '-t',
-        dest='threads',
+        "-t",
+        dest="threads",
         type=int,
         default=1,
         help="""Number of CPUs to use (default=1)""",
     )
     parser.add_argument(
-        '-d',
-        dest='db',
+        "-d",
+        dest="db",
         type=str,
         help="""Path to reference database
 By default, the MAGPURIFYDB environmental variable is used""",
     )
     parser.add_argument(
-        '-c',
-        dest='continue',
-        action='store_true',
+        "-c",
+        dest="continue",
+        action="store_true",
         default=False,
         help="""Go straight to quality estimation and skip all previous steps""",
     )
     parser.add_argument(
-        '--max_target_seqs',
+        "--max_target_seqs",
         type=int,
         default=1,
         help="""Maximum number of targets reported in BLAST table (default=1)""",
     )
     parser.add_argument(
-        '--cutoff_type',
-        choices=['strict', 'sensitive', 'none'],
-        default='strict',
+        "--cutoff_type",
+        choices=["strict", "sensitive", "none"],
+        default="strict",
         help="""Use strict or sensitive %%ID cutoff for taxonomically annotating genes (default=strict)""",
     )
     parser.add_argument(
-        '--seq_type',
-        choices=['dna', 'protein', 'both', 'either'],
-        default='protein',
+        "--seq_type",
+        choices=["dna", "protein", "both", "either"],
+        default="protein",
         help="""Choose to search genes versus DNA or protein database (default=protein)""",
     )
     parser.add_argument(
-        '--hit_type',
-        choices=['all_hits', 'top_hit'],
-        default='top_hit',
+        "--hit_type",
+        choices=["all_hits", "top_hit"],
+        default="top_hit",
         help="""Transfer taxonomy of all hits or top hit per gene (default=top_hit)""",
     )
     parser.add_argument(
-        '--exclude_clades',
+        "--exclude_clades",
         type=str,
         help="""Comma separated list of clades to exclude (ex: s__1300164.4)""",
     )
     parser.add_argument(
-        '--bin_fract',
+        "--bin_fract",
         type=float,
         default=0.7,
         help="""Min fraction of genes in bin that agree with consensus taxonomy for bin annotation (default=0.7)""",
     )
     parser.add_argument(
-        '--contig_fract',
+        "--contig_fract",
         type=float,
         default=1.0,
         help="""Min fraction of genes in that disagree with bin taxonomy for filtering (default=1.0)""",
     )
     parser.add_argument(
-        '--allow_noclass',
-        action='store_true',
+        "--allow_noclass",
+        action="store_true",
         default=False,
         help="""Allow a bin to be unclassfied and flag any classified contigs (default=False)""",
     )
@@ -103,23 +103,23 @@ def extract_homologs(tmp_dir):
     gene_to_aln = utility.fetch_hmm_best_hits(f"{tmp_dir}/phyeco.hmmsearch")
     # open output files
     outfiles = {}
-    marker_ids = set([aln['qacc'] for aln in list(gene_to_aln.values())])
+    marker_ids = set([aln["qacc"] for aln in list(gene_to_aln.values())])
     for marker_id in marker_ids:
         outfiles[marker_id] = {}
-        outfiles[marker_id]['ffn'] = open(f"{seqs_dir}/{marker_id}.ffn", "w")
-        outfiles[marker_id]['faa'] = open(f"{seqs_dir}/{marker_id}.faa", "w")
+        outfiles[marker_id]["ffn"] = open(f"{seqs_dir}/{marker_id}.ffn", "w")
+        outfiles[marker_id]["faa"] = open(f"{seqs_dir}/{marker_id}.faa", "w")
     # write seqs
-    for ext in ['ffn', 'faa']:
+    for ext in ["ffn", "faa"]:
         in_path = f"{tmp_dir}/genes.{ext}"
         for id, seq in utility.parse_fasta(in_path):
             if id in gene_to_aln:
-                marker_id = gene_to_aln[id]['qacc']
-                seq = seq.rstrip('*')
-                outfiles[marker_id][ext].write('>' + id + '\n' + seq + '\n')
+                marker_id = gene_to_aln[id]["qacc"]
+                seq = seq.rstrip("*")
+                outfiles[marker_id][ext].write(">" + id + "\n" + seq + "\n")
     # close files
     for marker_id in outfiles:
-        outfiles[marker_id]['ffn'].close()
-        outfiles[marker_id]['faa'].close()
+        outfiles[marker_id]["ffn"].close()
+        outfiles[marker_id]["faa"].close()
 
 
 def align_homologs(db_dir, tmp_dir, seq_type, threads):
@@ -128,22 +128,22 @@ def align_homologs(db_dir, tmp_dir, seq_type, threads):
         os.makedirs(aln_dir)
     seq_files = os.listdir(f"{tmp_dir}/markers")
     for file_index, seq_file in enumerate(seq_files):
-        marker_id, ext = seq_file.split('.')
-        if ext == 'ffn' and seq_type == 'protein':
+        marker_id, ext = seq_file.split(".")
+        if ext == "ffn" and seq_type == "protein":
             continue
-        elif ext == 'faa' and seq_type == 'dna':
+        elif ext == "faa" and seq_type == "dna":
             continue
-        if ext == 'faa':
-            program = 'blastp' if ext == 'faa' else 'blastn'
-            db_path = f'{db_dir}/phylo-markers/{program}/{marker_id}'
-            query_path = f'{tmp_dir}/markers/{marker_id}.{ext}'
-            out_path = f'{tmp_dir}/alns/{marker_id}.{ext}.m8'
+        if ext == "faa":
+            program = "blastp" if ext == "faa" else "blastn"
+            db_path = f"{db_dir}/phylo-markers/{program}/{marker_id}"
+            query_path = f"{tmp_dir}/markers/{marker_id}.{ext}"
+            out_path = f"{tmp_dir}/alns/{marker_id}.{ext}.m8"
             utility.run_blastp(db_path, query_path, out_path, threads)
         else:
-            program = 'blastn'
-            db_path = f'{db_dir}/phylo-markers/{program}/{marker_id}'
-            query_path = f'{tmp_dir}/markers/{marker_id}.{ext}'
-            out_path = f'{tmp_dir}/alns/{marker_id}.{ext}.m8'
+            program = "blastn"
+            db_path = f"{db_dir}/phylo-markers/{program}/{marker_id}"
+            query_path = f"{tmp_dir}/markers/{marker_id}.{ext}"
+            out_path = f"{tmp_dir}/alns/{marker_id}.{ext}.m8"
             utility.run_blastp(db_path, query_path, out_path, threads)
 
 
@@ -164,7 +164,7 @@ class Bin:
 
             # loop over annotations for each gene
             for index, annotation in enumerate(gene.annotations):
-                is_match = any([c in annotation.taxon for c in clades.split(',')])
+                is_match = any([c in annotation.taxon for c in clades.split(",")])
                 if is_match:
                     exclude_indexes.append(index)
 
@@ -183,7 +183,7 @@ class Bin:
 		determine taxon and rank of bin based on lowest rank
 		where at least <min_fraction> of genes match the consensus annotation
 		"""
-        ranks = ['s', 'g', 'f', 'o', 'c', 'p']
+        ranks = ["s", "g", "f", "o", "c", "p"]
         for rank_index, rank in enumerate(ranks):
 
             # get list of taxa across all genes
@@ -244,7 +244,7 @@ class Annotation:
 
     def add_taxon(self, genome_taxon, rank_index):
         for i in range(rank_index, 6):
-            self.taxon[i] = genome_taxon.split(';')[i]
+            self.taxon[i] = genome_taxon.split(";")[i]
 
 
 class Contig:
@@ -279,54 +279,54 @@ def flag_contigs(db_dir, tmp_dir, args):
     # step 0. read in reference data files
     # cutoffs
     cutoffs = {}
-    cutoffs_path = f'{db_dir}/phylo-markers/max_fscores.tsv'
+    cutoffs_path = f"{db_dir}/phylo-markers/max_fscores.tsv"
     reader = csv.DictReader(open(cutoffs_path), delimiter="\t")
     for r in reader:
-        key = (r['marker_id'], r['seq_type'], r['score_type'], r['taxlevel'])
-        value = {'sensitive': r['cutoff_lower'], 'strict': r['cutoff_upper'], 'none': 0.0}
+        key = (r["marker_id"], r["seq_type"], r["score_type"], r["taxlevel"])
+        value = {"sensitive": r["cutoff_lower"], "strict": r["cutoff_upper"], "none": 0.0}
         cutoffs[key] = value
     # taxonomy
     taxonomy = {}
-    taxonomy_path = f'{db_dir}/phylo-markers/genome_taxonomy.tsv'
+    taxonomy_path = f"{db_dir}/phylo-markers/genome_taxonomy.tsv"
     reader = csv.DictReader(open(taxonomy_path), delimiter="\t")
     for r in reader:
-        taxonomy[r['genome_id']] = r['taxonomy']
+        taxonomy[r["genome_id"]] = r["taxonomy"]
     # clustered seqs
     clusters = {}
-    for type in ['ffn', 'faa']:
+    for type in ["ffn", "faa"]:
         clusters[type] = {}
-        for file in os.listdir(f'{db_dir}/phylo-markers/{type}'):
-            if file.split('.')[-1] == 'uc':
-                with open(f'{db_dir}/phylo-markers/{type}/{file}') as f:
+        for file in os.listdir(f"{db_dir}/phylo-markers/{type}"):
+            if file.split(".")[-1] == "uc":
+                with open(f"{db_dir}/phylo-markers/{type}/{file}") as f:
                     for l in f:
                         v = l.rstrip().split()
                         rep_id = v[-1]
                         seq_id = v[-2]
-                        if v[0] == 'S':
+                        if v[0] == "S":
                             clusters[type][seq_id] = [seq_id]
-                        elif v[0] == 'H':
+                        elif v[0] == "H":
                             clusters[type][rep_id].append(seq_id)
 
     # step 1. determine if bin is archaea or bacteria; initialize domain-level markers
     # to do: normalize counts by site of marker gene sets
     marker_ids = set([])
-    counts = {'bacteria': 0, 'archaea': 0}
-    for aln_file in os.listdir(f'{tmp_dir}/alns'):
+    counts = {"bacteria": 0, "archaea": 0}
+    for aln_file in os.listdir(f"{tmp_dir}/alns"):
         marker_id, seq_type, ext = aln_file.split(".")
         marker_ids.add(marker_id)
     for marker_id in marker_ids:
-        if 'B' in marker_id:
-            counts['bacteria'] += 1
-        elif 'A' in marker_id:
-            counts['archaea'] += 1
-    domain = 'bacteria' if counts['bacteria'] >= counts['archaea'] else 'archaea'
+        if "B" in marker_id:
+            counts["bacteria"] += 1
+        elif "A" in marker_id:
+            counts["archaea"] += 1
+    domain = "bacteria" if counts["bacteria"] >= counts["archaea"] else "archaea"
     markers = {}
     for marker_id in marker_ids:
-        if domain == 'bacteria' and 'B' in marker_id:
+        if domain == "bacteria" and "B" in marker_id:
             markers[marker_id] = Marker()
             markers[marker_id].id = marker_id
             markers[marker_id].genes = []
-        elif domain == 'archaea' and 'A' in marker_id:
+        elif domain == "archaea" and "A" in marker_id:
             markers[marker_id] = Marker()
             markers[marker_id].id = marker_id
             markers[marker_id].genes = []
@@ -336,24 +336,24 @@ def flag_contigs(db_dir, tmp_dir, args):
     bin.genes = {}
     hmm_path = f"{tmp_dir}/phyeco.hmmsearch"
     for gene_id, aln in list(utility.fetch_hmm_best_hits(hmm_path).items()):
-        if aln['qacc'] not in markers:
+        if aln["qacc"] not in markers:
             continue
         gene = Gene()
         gene.id = gene_id
-        gene.contig = gene_id.rsplit('_', 1)[0]
-        gene.marker = aln['qacc']
+        gene.contig = gene_id.rsplit("_", 1)[0]
+        gene.marker = aln["qacc"]
         bin.genes[gene_id] = gene
-        markers[aln['qacc']].genes.append(gene)
+        markers[aln["qacc"]].genes.append(gene)
 
     # annotate genes
     #    fetch all non-redundant taxonomic annotations for each gene
     seq_types = None
-    if args['seq_type'] in ['both', 'either']:
-        seq_types = ['ffn', 'faa']
-    elif args['seq_type'] == 'protein':
-        seq_types = ['faa']
+    if args["seq_type"] in ["both", "either"]:
+        seq_types = ["ffn", "faa"]
+    elif args["seq_type"] == "protein":
+        seq_types = ["faa"]
     else:
-        seq_types = ['ffn']
+        seq_types = ["ffn"]
 
     for seq_type in seq_types:
         for marker_id in markers:
@@ -363,8 +363,8 @@ def flag_contigs(db_dir, tmp_dir, args):
                 # fetch all unique taxonomies for target sequence
                 # a sequence can have multiple taxonomies if it was clustered with another sequence
                 genome_taxa = []
-                for target_id in clusters[seq_type][aln['tname']]:
-                    genome_id = target_id.split('_')[0]
+                for target_id in clusters[seq_type][aln["tname"]]:
+                    genome_id = target_id.split("_")[0]
                     if genome_id not in taxonomy:
                         continue
                     elif taxonomy[genome_id] in genome_taxa:
@@ -373,40 +373,40 @@ def flag_contigs(db_dir, tmp_dir, args):
                         genome_taxa.append(taxonomy[genome_id])
 
                 # loop over ranks; stop when gene has been annotated
-                for rank_index, rank in enumerate(['s', 'g', 'f', 'o', 'c', 'p']):
+                for rank_index, rank in enumerate(["s", "g", "f", "o", "c", "p"]):
 
                     # decide to use ffn or faa at species level
-                    if args['seq_type'] == 'either':
-                        if seq_type == 'ffn' and rank != 's':
+                    if args["seq_type"] == "either":
+                        if seq_type == "ffn" and rank != "s":
                             continue
-                        elif seq_type == 'faa' and rank == 's':
+                        elif seq_type == "faa" and rank == "s":
                             continue
 
                     # get minimum % identity cutoff for transfering taxonomy
                     #   if cutoff_type is None, indicates that no cutoff should be used
-                    min_pid = cutoffs[marker_id, seq_type, 'pid', rank][
-                        args['cutoff_type']
+                    min_pid = cutoffs[marker_id, seq_type, "pid", rank][
+                        args["cutoff_type"]
                     ]
 
-                    if float(aln['pid']) < float(min_pid):
+                    if float(aln["pid"]) < float(min_pid):
                         continue
 
                     # add taxonomy
                     for genome_taxon in genome_taxa:
                         annotation = Annotation()
                         annotation.add_taxon(genome_taxon, rank_index)
-                        annotation.score = float(aln['bitscore'])
-                        bin.genes[aln['qname']].annotations.append(annotation)
+                        annotation.score = float(aln["bitscore"])
+                        bin.genes[aln["qname"]].annotations.append(annotation)
 
                     # stop when gene has been annotated at lowest rank
                     break
 
     # optionally remove annotations matching <exclude_clades>
-    if args['exclude_clades'] is not None:
-        bin.exclude_clades(args['exclude_clades'])
+    if args["exclude_clades"] is not None:
+        bin.exclude_clades(args["exclude_clades"])
 
     # optionally take top hit only
-    if args['hit_type'] == 'top_hit':
+    if args["hit_type"] == "top_hit":
         bin.only_keep_top_hits()
 
     # create None annotations for unannotated genes
@@ -415,11 +415,11 @@ def flag_contigs(db_dir, tmp_dir, args):
             gene.annotations.append(Annotation())
 
     # classify bin
-    bin.classify_taxonomy(args['allow_noclass'], args['bin_fract'])
+    bin.classify_taxonomy(args["allow_noclass"], args["bin_fract"])
 
     # flag contigs with discrepant taxonomy
     bin.contigs = {}
-    for id, seq in utility.parse_fasta(args['fna']):
+    for id, seq in utility.parse_fasta(args["fna"]):
         bin.contigs[id] = Contig()
         bin.contigs[id].id = id
         bin.contigs[id].length = len(seq)
@@ -430,7 +430,7 @@ def flag_contigs(db_dir, tmp_dir, args):
     if bin.cons_taxon is not None:
         for contig in bin.contigs.values():
             contig.compare_taxonomy(bin)
-            contig.flag(args['contig_fract'])
+            contig.flag(args["contig_fract"])
 
     # write results
     flagged_contigs = []
@@ -446,27 +446,28 @@ def main():
     args = parse_args()
     utility.add_tmp_dir(args)
     utility.check_input(args)
-    utility.check_dependencies(['prodigal', 'hmmsearch', 'blastp', 'blastn'])
+    utility.check_dependencies(["prodigal", "hmmsearch", "blastp", "blastn"])
     utility.check_database(args)
 
     print("\n## Calling genes with Prodigal")
-    utility.run_prodigal(args['fna'], args['tmp_dir'])
+    utility.run_prodigal(args["fna"], args["tmp_dir"])
     print(f"   all genes: {args['tmp_dir']}/genes.[ffn|faa]")
 
     print("\n## Identifying PhyEco phylogenetic marker genes with HMMER")
-    utility.run_hmmsearch(args['db'], args['tmp_dir'], args['tmp_dir'], args['threads'])
-    extract_homologs(args['tmp_dir'])
+    utility.run_hmmsearch(args["db"], args["tmp_dir"], args["tmp_dir"], args["threads"])
+    extract_homologs(args["tmp_dir"])
     print(f"   hmm results: {args['tmp_dir']}/phyeco.hmmsearch")
     print(f"   marker genes: {args['tmp_dir']}/markers")
 
     print("\n## Performing pairwise BLAST alignment of marker genes against database")
-    align_homologs(args['db'], args['tmp_dir'], args['seq_type'], args['threads'])
+    align_homologs(args["db"], args["tmp_dir"], args["seq_type"], args["threads"])
     print(f"   blast results: {args['tmp_dir']}/alns")
 
     print("\n## Finding taxonomic outliers")
-    flagged = flag_contigs(args['db'], args['tmp_dir'], args)
+    flagged = flag_contigs(args["db"], args["tmp_dir"], args)
     out = f"{args['tmp_dir']}/flagged_contigs"
     print(f"   {len(flagged)} flagged contigs: {out}")
-    with open(out, 'w') as f:
+    with open(out, "w") as f:
         for contig in flagged:
-            f.write(contig + '\n')
+            f.write(contig + "\n")
+

--- a/magpurify/utility.py
+++ b/magpurify/utility.py
@@ -5,7 +5,7 @@ from Bio import Seq, SeqIO
 
 
 def add_tmp_dir(args):
-    tmp_dir = "%s/%s" % (args["out"], args["program"])
+    tmp_dir = f"{args['out']}/{args['program']}"
     if not os.path.exists(tmp_dir):
         os.makedirs(tmp_dir)
     args["tmp_dir"] = tmp_dir

--- a/magpurify/utility.py
+++ b/magpurify/utility.py
@@ -13,14 +13,14 @@ def add_tmp_dir(args):
 
 def check_input(args):
     if not os.path.exists(args['fna']):
-        error = "\nInput file not found: %s\n" % args['fna']
+        error = f"\nInput file not found: {args['fna']}\n"
         sys.exit(error)
 
 
 def check_dependencies(programs):
     for program in programs:
         if not exists_on_env_path(program):
-            error = "\nRequired program '%s' not found\n" % program
+            error = f"\nRequired program '{program}' not found\n"
             error += "Make sure this program has been installed and added to your PATH\n"
             sys.exit(error)
 
@@ -60,10 +60,7 @@ def run_process(command):
     process = sp.Popen(command, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
     out, err = process.communicate()
     if process.returncode != 0:
-        err_message = "\nError encountered executing:\n%s\n\nError message:\n%s\n" % (
-            command,
-            err,
-        )
+        err_message = f"\nError encountered executing:\n{command}\n\nError message:\n{err}\n"
         sys.exit(err_message)
     return out, err
 
@@ -216,59 +213,68 @@ def fetch_hmm_best_hits(fpath):
     return gene_to_aln
 
 
+def run_coverm(bam_list, out_dir):
+    cmd = "coverm contig "
+    cmd += "--contig-end-exclusion 75 "
+    cmd += "--min-read-percent-identity 0.97 "
+    cmd += f"--bam-files {' '.join(bam_list)} "
+    cmd += f"> {out_dir}/coverage.tsv"
+    out, err = run_process(cmd)
+
+
 def run_prodigal(fna_path, out_dir):
     cmd = "prodigal "
-    cmd += "-i %s " % fna_path  # input fna
-    cmd += "-a %s/genes.faa " % out_dir  # protein seqs
-    cmd += "-d %s/genes.ffn " % out_dir  # nucleotide seqs
-    cmd += "-o %s/genes.out " % out_dir  # prodigal output
+    cmd += f"-i {fna_path} "  # input fna
+    cmd += f"-a {out_dir}/genes.faa "  # protein seqs
+    cmd += f"-d {out_dir}/genes.ffn "  # nucleotide seqs
+    cmd += f"-o {out_dir}/genes.out "  # prodigal output
     cmd += "> /dev/null"  # prodigal output
     out, err = run_process(cmd)
 
 
 def run_lastal(db_dir, out_dir, threads=1, seed_freq=10):
     cmd = "lastal -p BLOSUM62 -P 1 -f blasttab+ "
-    cmd += "-m %s " % seed_freq
-    cmd += "%s/clade-markers/markers.faa " % db_dir
-    cmd += "%s/genes.faa " % out_dir
-    cmd += "-P %s " % threads
-    cmd += "> %s/genes.m8 " % out_dir
+    cmd += f"-m {seed_freq} "
+    cmd += f"{db_dir}/clade-markers/markers.faa "
+    cmd += f"{out_dir}/genes.faa "
+    cmd += f"-P {threads} "
+    cmd += f"> {out_dir}/genes.m8 "
     out, err = run_process(cmd)
 
 
 def run_hmmsearch(db_dir, in_path, out_dir, threads=1):
     cmd = "hmmsearch "
     cmd += "--noali "
-    cmd += "--domtblout %s/phyeco.hmmsearch " % out_dir
-    cmd += "--cpu %s " % threads
+    cmd += f"--domtblout {out_dir}/phyeco.hmmsearch "
+    cmd += f"--cpu {threads} "
     cmd += "--cut_ga "
-    cmd += "%s/phylo-markers/PhyEco.hmm " % db_dir
-    cmd += "%s/genes.faa " % in_path
+    cmd += f"{db_dir}/phylo-markers/PhyEco.hmm "
+    cmd += f"{in_path}/genes.faa "
     out, err = run_process(cmd)
 
 
 def run_blastp(db_path, query_path, out_path, threads=1, max_targets=1, qcov=40):
     cmd = "blastp "
-    cmd += "-db %s " % db_path
-    cmd += "-query %s " % query_path
-    cmd += "-out %s " % out_path
+    cmd += f"-db {db_path} "
+    cmd += f"-query {query_path} "
+    cmd += f"-out {out_path} "
     cmd += "-outfmt '6 std qlen slen' "
-    cmd += "-num_threads %s " % threads
-    cmd += "-max_target_seqs %s " % max_targets
-    cmd += "-qcov_hsp_perc %s " % qcov
+    cmd += f"-num_threads {threads} "
+    cmd += f"-max_target_seqs {max_targets} "
+    cmd += f"-qcov_hsp_perc {qcov} "
     cmd += "-max_hsps 1 "
     out, err = run_process(cmd)
 
 
 def run_blastn(db_path, query_path, out_path, threads=1, max_targets=1, qcov=40):
     cmd = "blastn -task blastn "
-    cmd += "-db %s " % db_path
-    cmd += "-query %s " % query_path
-    cmd += "-out %s " % out_path
+    cmd += f"-db {db_path} "
+    cmd += f"-query {query_path} "
+    cmd += f"-out {out_path} "
     cmd += "-outfmt '6 std qlen slen' "
-    cmd += "-num_threads %s " % threads
-    cmd += "-max_target_seqs %s " % max_targets
-    cmd += "-qcov_hsp_perc %s " % qcov
+    cmd += f"-num_threads {threads} "
+    cmd += f"-max_target_seqs {max_targets} "
+    cmd += f"-qcov_hsp_perc {qcov} "
     cmd += "-max_hsps 1 "
     out, err = run_process(cmd)
 

--- a/magpurify/utility.py
+++ b/magpurify/utility.py
@@ -5,7 +5,7 @@ from Bio import Seq, SeqIO
 
 
 def add_tmp_dir(args):
-    tmp_dir = '%s/%s' % (args['out'], args['program'])
+    tmp_dir = "%s/%s" % (args['out'], args['program'])
     if not os.path.exists(tmp_dir):
         os.makedirs(tmp_dir)
     args['tmp_dir'] = tmp_dir
@@ -43,7 +43,7 @@ def check_database(args):
         error += "Or set the MAGPURIFYDB environmental variable: export MAGPURIFYDB=/path/to/MAGpurify_db_v1.0.0\n"
         sys.exit(error)
     if not os.path.isdir(args['db']):
-        error = "\nError: Specified reference database does not exist: %s\n" % args['db']
+        error = f"\nError: Specified reference database does not exist: {args['db']}\n"
         error += (
             "\nCheck that you've entered the path correctly and the database exists\n"
         )

--- a/magpurify/utility.py
+++ b/magpurify/utility.py
@@ -5,14 +5,14 @@ from Bio import Seq, SeqIO
 
 
 def add_tmp_dir(args):
-    tmp_dir = "%s/%s" % (args['out'], args['program'])
+    tmp_dir = "%s/%s" % (args["out"], args["program"])
     if not os.path.exists(tmp_dir):
         os.makedirs(tmp_dir)
-    args['tmp_dir'] = tmp_dir
+    args["tmp_dir"] = tmp_dir
 
 
 def check_input(args):
-    if not os.path.exists(args['fna']):
+    if not os.path.exists(args["fna"]):
         error = f"\nInput file not found: {args['fna']}\n"
         sys.exit(error)
 
@@ -28,21 +28,21 @@ def check_dependencies(programs):
 def exists_on_env_path(program):
     """ Check whether program exists in PATH and is executable """
     for dir in os.environ["PATH"].split(os.pathsep):
-        fpath = dir + '/' + program
+        fpath = dir + "/" + program
         if os.path.exists(fpath) and os.access(fpath, os.X_OK):
             return True
     return False
 
 
 def check_database(args):
-    if args['db'] is None and 'MAGPURIFYDB' in os.environ:
-        args['db'] = os.environ['MAGPURIFYDB']
-    if args['db'] is None:
+    if args["db"] is None and "MAGPURIFYDB" in os.environ:
+        args["db"] = os.environ["MAGPURIFYDB"]
+    if args["db"] is None:
         error = "\nError: No reference database specified\n"
         error += "Use the flag -d to specify a database,\n"
         error += "Or set the MAGPURIFYDB environmental variable: export MAGPURIFYDB=/path/to/MAGpurify_db_v1.0.0\n"
         sys.exit(error)
-    if not os.path.isdir(args['db']):
+    if not os.path.isdir(args["db"]):
         error = f"\nError: Specified reference database does not exist: {args['db']}\n"
         error += (
             "\nCheck that you've entered the path correctly and the database exists\n"
@@ -60,76 +60,78 @@ def run_process(command):
     process = sp.Popen(command, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
     out, err = process.communicate()
     if process.returncode != 0:
-        err_message = f"\nError encountered executing:\n{command}\n\nError message:\n{err}\n"
+        err_message = (
+            f"\nError encountered executing:\n{command}\n\nError message:\n{err}\n"
+        )
         sys.exit(err_message)
     return out, err
 
 
 def parse_last(inpath):
     fields = [
-        'qid',
-        'tid',
-        'pid',
-        'aln',
-        'mis',
-        'gap',
-        'qstart',
-        'qend',
-        'tstart',
-        'tend',
-        'eval',
-        'score',
-        'qlen',
-        'tlen',
+        "qid",
+        "tid",
+        "pid",
+        "aln",
+        "mis",
+        "gap",
+        "qstart",
+        "qend",
+        "tstart",
+        "tend",
+        "eval",
+        "score",
+        "qlen",
+        "tlen",
     ]
     for line in open(inpath):
-        if line[0] == '#':
+        if line[0] == "#":
             continue
         else:
             values = line.rstrip().split()
             d = dict([(f, v) for f, v in zip(fields, values)])
-            d['qcov'] = float(d['aln']) / float(d['qlen'])
-            d['tcov'] = float(d['aln']) / float(d['tlen'])
+            d["qcov"] = float(d["aln"]) / float(d["qlen"])
+            d["tcov"] = float(d["aln"]) / float(d["tlen"])
             yield d
 
 
-def parse_blast(input, type='file'):
+def parse_blast(input, type="file"):
     formats = [
-        ('qname', str),
-        ('tname', str),
-        ('pid', float),
-        ('aln', int),
-        ('mis', int),
-        ('gap', int),
-        ('qstart', int),
-        ('qend', int),
-        ('tstart', int),
-        ('tend', int),
-        ('evalue', float),
-        ('bitscore', float),
-        ('qlen', int),
-        ('tlen', int),
+        ("qname", str),
+        ("tname", str),
+        ("pid", float),
+        ("aln", int),
+        ("mis", int),
+        ("gap", int),
+        ("qstart", int),
+        ("qend", int),
+        ("tstart", int),
+        ("tend", int),
+        ("evalue", float),
+        ("bitscore", float),
+        ("qlen", int),
+        ("tlen", int),
     ]
-    if type == 'file':
-        lines = open(input).read().rstrip('\n').split('\n')
+    if type == "file":
+        lines = open(input).read().rstrip("\n").split("\n")
     else:
-        lines = input.rstrip('\n').split('\n')
-    if lines == ['']:
+        lines = input.rstrip("\n").split("\n")
+    if lines == [""]:
         return
     for line in lines:
-        values = line.split('\t')
+        values = line.split("\t")
         record = dict([(f[0], f[1](v)) for f, v in zip(formats, values)])
-        record['qcov'] = 100 * record['aln'] / float(record['qlen'])
-        record['tcov'] = 100 * record['aln'] / float(record['tlen'])
+        record["qcov"] = 100 * record["aln"] / float(record["qlen"])
+        record["tcov"] = 100 * record["aln"] / float(record["tlen"])
         yield record
 
 
 def parse_mash(fpath):
-    fields = ['query', 'target', 'dist', 'pvalue', 'fraction']
+    fields = ["query", "target", "dist", "pvalue", "fraction"]
     formats = [str, str, float, float, str]
     out = open(fpath).read()
     if len(out) > 0:
-        lines = out.rstrip('\n').split('\n')
+        lines = out.rstrip("\n").split("\n")
         for line in lines:
             values = line.split()
             rec = dict([(f, m(v)) for f, m, v in zip(fields, formats, values)])
@@ -139,29 +141,29 @@ def parse_mash(fpath):
 def parse_hmmsearch(fpath):
     with open(fpath) as infile:
         fields = [
-            'tname',
-            'tacc',
-            'tlen',
-            'qname',
-            'qacc',
-            'qlen',
-            'evalue',
-            'score',
-            'bias',
-            'ndom',
-            'tdom',
-            'c-evalue',
-            'i-evalue',
-            'domscore',
-            'dombias',
-            'hmmfrom',
-            'hmmto',
-            'alifrom',
-            'alito',
-            'envfrom',
-            'envto',
-            'prob',
-            'tdesc',
+            "tname",
+            "tacc",
+            "tlen",
+            "qname",
+            "qacc",
+            "qlen",
+            "evalue",
+            "score",
+            "bias",
+            "ndom",
+            "tdom",
+            "c-evalue",
+            "i-evalue",
+            "domscore",
+            "dombias",
+            "hmmfrom",
+            "hmmto",
+            "alifrom",
+            "alito",
+            "envfrom",
+            "envto",
+            "prob",
+            "tdesc",
         ]
         formts = [
             str,
@@ -189,27 +191,27 @@ def parse_hmmsearch(fpath):
             str,
         ]
         for line in infile:
-            if line[0] == '#':
+            if line[0] == "#":
                 continue
-            values = line.rstrip('\n').split(None, 22)
+            values = line.rstrip("\n").split(None, 22)
             r = dict(
                 [
                     (field, format(value))
                     for field, format, value in zip(fields, formts, values)
                 ]
             )
-            r['tcov'] = float(r['alito'] - r['alifrom'] + 1) / r['tlen']  # target is gene
-            r['qcov'] = float(r['hmmto'] - r['hmmfrom'] + 1) / r['qlen']  # query is hmm
+            r["tcov"] = float(r["alito"] - r["alifrom"] + 1) / r["tlen"]  # target is gene
+            r["qcov"] = float(r["hmmto"] - r["hmmfrom"] + 1) / r["qlen"]  # query is hmm
             yield r
 
 
 def fetch_hmm_best_hits(fpath):
     gene_to_aln = {}
     for aln in parse_hmmsearch(fpath):
-        if aln['tname'] not in gene_to_aln:
-            gene_to_aln[aln['tname']] = aln
-        elif aln['score'] > gene_to_aln[aln['tname']]['score']:
-            gene_to_aln[aln['tname']] = aln
+        if aln["tname"] not in gene_to_aln:
+            gene_to_aln[aln["tname"]] = aln
+        elif aln["score"] > gene_to_aln[aln["tname"]]["score"]:
+            gene_to_aln[aln["tname"]] = aln
     return gene_to_aln
 
 
@@ -281,7 +283,7 @@ def run_blastn(db_path, query_path, out_path, threads=1, max_targets=1, qcov=40)
 
 def parse_fasta(path):
     with open(path) as file:
-        for record in SeqIO.parse(file, 'fasta'):
+        for record in SeqIO.parse(file, "fasta"):
             id = record.id
             seq = str(record.seq).upper()
             yield id, seq

--- a/run_qc.py
+++ b/run_qc.py
@@ -16,6 +16,7 @@ def get_program():
         print('      conspecific: find contigs that fail to align to closely related genomes')
         print('       tetra-freq: find contigs with outlier tetranucleotide frequency')
         print('       gc-content: find contigs with outlier gc content')
+        print('         coverage: find contigs with outlier coverage profile')
         print('     known-contam: find contigs that match a database of known contaminants')
         print('        clean-bin: remove identified contigs from bin')
         print('')
@@ -27,11 +28,11 @@ def get_program():
         'conspecific',
         'tetra-freq',
         'gc-content',
+        'coverage',
         'known-contam',
         'clean-bin',
     ]:
         sys.exit("\nError: Unrecognized command: '%s'\n" % sys.argv[1])
-        quit()
     else:
         return sys.argv[1]
 
@@ -64,6 +65,11 @@ if __name__ == "__main__":
         from magpurify import gc
 
         gc.main()
+
+    if program == 'coverage':
+        from magpurify import coverage
+
+        coverage.main()
 
     if program == 'known-contam':
         from magpurify import contam

--- a/run_qc.py
+++ b/run_qc.py
@@ -5,32 +5,32 @@ import sys
 
 
 def get_program():
-    if len(sys.argv) == 1 or sys.argv[1] in ['-h', '--help']:
-        print('MAGpurify: Identify and remove incorrectly binned contigs from metagenome-assembled genomes')
-        print('')
-        print('Usage: run_qc.py <command> [options]')
-        print('')
-        print('Commands:')
-        print('    phylo-markers: find taxonomic discordant contigs using db of phylogenetic marker genes')
-        print('    clade-markers: find taxonomic discordant contigs using db of clade-specific marker genes')
-        print('      conspecific: find contigs that fail to align to closely related genomes')
-        print('       tetra-freq: find contigs with outlier tetranucleotide frequency')
-        print('       gc-content: find contigs with outlier gc content')
-        print('         coverage: find contigs with outlier coverage profile')
-        print('     known-contam: find contigs that match a database of known contaminants')
-        print('        clean-bin: remove identified contigs from bin')
-        print('')
-        print('Note: use run_qc.py <command> -h to view usage for a specific command')
+    if len(sys.argv) == 1 or sys.argv[1] in ["-h", "--help"]:
+        print("MAGpurify: Identify and remove incorrectly binned contigs from metagenome-assembled genomes")
+        print("")
+        print("Usage: run_qc.py <command> [options]")
+        print("")
+        print("Commands:")
+        print("    phylo-markers: find taxonomic discordant contigs using db of phylogenetic marker genes")
+        print("    clade-markers: find taxonomic discordant contigs using db of clade-specific marker genes")
+        print("      conspecific: find contigs that fail to align to closely related genomes")
+        print("       tetra-freq: find contigs with outlier tetranucleotide frequency")
+        print("       gc-content: find contigs with outlier gc content")
+        print("         coverage: find contigs with outlier coverage profile")
+        print("     known-contam: find contigs that match a database of known contaminants")
+        print("        clean-bin: remove identified contigs from bin")
+        print("")
+        print("Note: use run_qc.py <command> -h to view usage for a specific command")
         quit()
     elif sys.argv[1] not in [
-        'phylo-markers',
-        'clade-markers',
-        'conspecific',
-        'tetra-freq',
-        'gc-content',
-        'coverage',
-        'known-contam',
-        'clean-bin',
+        "phylo-markers",
+        "clade-markers",
+        "conspecific",
+        "tetra-freq",
+        "gc-content",
+        "coverage",
+        "known-contam",
+        "clean-bin",
     ]:
         sys.exit("\nError: Unrecognized command: '%s'\n" % sys.argv[1])
     else:
@@ -41,42 +41,42 @@ if __name__ == "__main__":
 
     program = get_program()
 
-    if program == 'phylo-markers':
+    if program == "phylo-markers":
         from magpurify import uscmg
 
         uscmg.main()
 
-    if program == 'clade-markers':
+    if program == "clade-markers":
         from magpurify import csmg
 
         csmg.main()
 
-    if program == 'conspecific':
+    if program == "conspecific":
         from magpurify import conspecific
 
         conspecific.main()
 
-    if program == 'tetra-freq':
+    if program == "tetra-freq":
         from magpurify import tetra
 
         tetra.main()
 
-    if program == 'gc-content':
+    if program == "gc-content":
         from magpurify import gc
 
         gc.main()
 
-    if program == 'coverage':
+    if program == "coverage":
         from magpurify import coverage
 
         coverage.main()
 
-    if program == 'known-contam':
+    if program == "known-contam":
         from magpurify import contam
 
         contam.main()
 
-    if program == 'clean-bin':
+    if program == "clean-bin":
         from magpurify import clean
 
         clean.main()


### PR DESCRIPTION
This PR adds the `coverage` module to MAGpurify.

## Changes
- The module calls [`coverm`](https://github.com/wwood/CoverM) to compute the contig coverages from BAM files.
- I'm using the parameters [recommended by the MetaBAT2 developers](https://bitbucket.org/berkeleylab/metabat/issues/48/jgi_summarize_bam_contig_depths-coverage): `--contig-end-exclusion 75` and `--min-read-percent-identity 0.97`.
- The user can input BAM files created from mapping the reads to the MAG or to the original metagenome. In the later, the module will only select that appear in the MAG.
- **[Up for discussion]** The user can input multiple BAM files. If so, only the BAM with the largest average coverage will be the used for outlier identification.
- **[Up for discussion]** Outlier detection is only performed if the average coverage is over 1.0 in at least in one sample.
- **[Up for discussion]** In the paper it is stated: "*contigs removed with read depth +/- 5x the mean read depth of the bin*". My interpretation of that sentence is that the average contig coverage is computed and then contigs with coverage greater than 5*average or less than (1/5)*coverage are flagged as outliers. Is my interpretation correct?
- The optional parameter `--max-deviation` allows the user to change the stringency of the refinement.

```python
outliers = ((mag_coverage_df / mag_coverage_df.mean()) >= args["max_deviation"]) | (
    (mag_coverage_df / mag_coverage_df.mean()) <= 1 / args["max_deviation"]
)
```